### PR TITLE
Update how queue & playback handle shuffled tracks

### DIFF
--- a/src/app/components/collection/collection-tracks/collection-tracks-table/collection-tracks-table.component.html
+++ b/src/app/components/collection/collection-tracks/collection-tracks-table/collection-tracks-table.component.html
@@ -111,7 +111,7 @@
                 class="tracks-table-row"
                 [ngClass]="{ 'selected-item-background-important': track.isSelected }"
                 (mousedown)="setSelectedTracks($event, track)"
-                (dblclick)="playbackService.enqueueAndPlayTracks(this.orderedTracks, track)"
+                (dblclick)="playbackService.enqueueAndPlayTracksFromDoubleClick(this.orderedTracks, track)"
             >
                 <td>
                     <div class="ellipsis" [ngClass]="{ 'accent-color': track.isPlaying }">

--- a/src/app/components/collection/track-browser/track-browser.component.html
+++ b/src/app/components/collection/track-browser/track-browser.component.html
@@ -22,7 +22,7 @@
             <app-track
                 [track]="track"
                 canShowHeader="true"
-                (dblclick)="playbackService.enqueueAndPlayTracks(this.orderedTracks, track)"
+                (dblclick)="playbackService.enqueueAndPlayTracksFromDoubleClick(this.orderedTracks, track)"
                 (contextmenu)="onTrackContextMenuAsync($event, track)"
             ></app-track>
         </div>

--- a/src/app/services/file/file.service.spec.ts
+++ b/src/app/services/file/file.service.spec.ts
@@ -93,9 +93,7 @@ describe('FileService', () => {
                         It.is<TrackModel[]>(
                             (trackModels: TrackModel[]) =>
                                 trackModels.length === 2 && trackModels[0].path === 'file 1.mp3' && trackModels[1].path === 'file 2.ogg'
-                        ),
-                        It.is<TrackModel>((trackModel: TrackModel) => trackModel.path === 'file 1.mp3')
-                    ),
+                    )),
                 Times.once()
             );
         });
@@ -109,7 +107,7 @@ describe('FileService', () => {
             await flushPromises();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
 
         it('should not enqueue and play anything if parameters are empty when arguments are received', async () => {
@@ -121,7 +119,7 @@ describe('FileService', () => {
             await flushPromises();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
 
         it('should not enqueue and play anything if there are no playable tracks found as parameters when arguments are received', async () => {
@@ -133,7 +131,7 @@ describe('FileService', () => {
             await flushPromises();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
     });
 
@@ -180,8 +178,7 @@ describe('FileService', () => {
                         It.is<TrackModel[]>(
                             (trackModels: TrackModel[]) =>
                                 trackModels.length === 2 && trackModels[0].path === 'file 1.mp3' && trackModels[1].path === 'file 2.ogg'
-                        ),
-                        It.is<TrackModel>((trackModel: TrackModel) => trackModel.path === 'file 1.mp3')
+                        )
                     ),
                 Times.once()
             );
@@ -196,7 +193,7 @@ describe('FileService', () => {
             await service.enqueueParameterFilesAsync();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
 
         it('should not enqueue and play anything if parameters are empty', async () => {
@@ -208,7 +205,7 @@ describe('FileService', () => {
             await service.enqueueParameterFilesAsync();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
 
         it('should not enqueue and play anything if there are no playable tracks found as parameters', async () => {
@@ -220,7 +217,7 @@ describe('FileService', () => {
             await service.enqueueParameterFilesAsync();
 
             // Assert
-            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny(), It.isAny()), Times.never());
+            playbackServiceMock.verify((x) => x.enqueueAndPlayTracks(It.isAny()), Times.never());
         });
     });
 });

--- a/src/app/services/file/file.service.ts
+++ b/src/app/services/file/file.service.ts
@@ -75,7 +75,7 @@ export class FileService implements BaseFileService {
             }
 
             if (trackModels.length > 0) {
-                this.playbackService.enqueueAndPlayTracks(trackModels, trackModels[0]);
+                this.playbackService.enqueueAndPlayTracks(trackModels);
             }
         } catch (e) {
             this.logger.error(

--- a/src/app/services/playback/base-playback.service.ts
+++ b/src/app/services/playback/base-playback.service.ts
@@ -29,7 +29,7 @@ export abstract class BasePlaybackService {
     public abstract togglePlayback(): void;
     public abstract toggleLoopMode(): void;
     public abstract toggleIsShuffled(): void;
-    public abstract enqueueAndPlayTracks(tracksToEnqueue: TrackModel[], trackToPlay: TrackModel): void;
+    public abstract enqueueAndPlayTracks(tracksToEnqueue: TrackModel[]): void;
     public abstract enqueueAndPlayArtist(artistToPlay: ArtistModel, artistType: ArtistType): void;
     public abstract enqueueAndPlayGenre(genreToPlay: GenreModel): void;
     public abstract enqueueAndPlayAlbum(albumToPlay: AlbumModel): void;

--- a/src/app/services/playback/playback.service.ts
+++ b/src/app/services/playback/playback.service.ts
@@ -59,7 +59,9 @@ export class PlaybackService implements BasePlaybackService {
         const trackModels: TrackModels = new TrackModels();
 
         if (this.queue.tracks != undefined) {
-            for (const track of this.queue.tracks) {
+            // add tracks to playback queue in playback order so that they will be loaded in the playback order into the view
+            // so that the user can see what is coming next in the queue
+            for (const track of this.queue.getTracksInPlaybackOrder()) {
                 trackModels.addTrack(track);
             }
         }
@@ -111,7 +113,21 @@ export class PlaybackService implements BasePlaybackService {
     public playbackStopped$: Observable<void> = this.playbackStopped.asObservable();
     public playbackSkipped$: Observable<void> = this.playbackSkipped.asObservable();
 
-    public enqueueAndPlayTracks(tracksToEnqueue: TrackModel[], trackToPlay: TrackModel): void {
+    public enqueueAndPlayTracks(tracksToEnqueue: TrackModel[]): void {
+        if (tracksToEnqueue == undefined) {
+            return;
+        }
+
+        if (tracksToEnqueue.length === 0) {
+            return;
+        }
+
+        this.queue.setTracks(tracksToEnqueue, this.isShuffled);
+        // play first track in queue (will be a random track if queue is shuffled)
+        this.play(this.playbackQueue.tracks[0], false);
+    }
+
+    public enqueueAndPlayTracksFromDoubleClick(tracksToEnqueue: TrackModel[], trackToPlay: TrackModel): void {
         if (tracksToEnqueue == undefined) {
             return;
         }
@@ -139,7 +155,7 @@ export class PlaybackService implements BasePlaybackService {
 
         const tracksForArtists: TrackModels = this.trackService.getTracksForArtists([artistToPlay.displayName], artistType);
         const orderedTracks: TrackModel[] = this.trackOrdering.getTracksOrderedByAlbum(tracksForArtists.tracks);
-        this.enqueueAndPlayTracks(orderedTracks, orderedTracks[0]);
+        this.enqueueAndPlayTracks(orderedTracks);
     }
 
     public enqueueAndPlayGenre(genreToPlay: GenreModel): void {
@@ -149,7 +165,7 @@ export class PlaybackService implements BasePlaybackService {
 
         const tracksForGenre: TrackModels = this.trackService.getTracksForGenres([genreToPlay.displayName]);
         const orderedTracks: TrackModel[] = this.trackOrdering.getTracksOrderedByAlbum(tracksForGenre.tracks);
-        this.enqueueAndPlayTracks(orderedTracks, orderedTracks[0]);
+        this.enqueueAndPlayTracks(orderedTracks);
     }
 
     public enqueueAndPlayAlbum(albumToPlay: AlbumModel): void {
@@ -159,7 +175,7 @@ export class PlaybackService implements BasePlaybackService {
 
         const tracksForAlbum: TrackModels = this.trackService.getTracksForAlbums([albumToPlay.albumKey]);
         const orderedTracks: TrackModel[] = this.trackOrdering.getTracksOrderedByAlbum(tracksForAlbum.tracks);
-        this.enqueueAndPlayTracks(orderedTracks, orderedTracks[0]);
+        this.enqueueAndPlayTracks(orderedTracks);
     }
 
     public async enqueueAndPlayPlaylistAsync(playlistToPlay: PlaylistModel): Promise<void> {
@@ -168,7 +184,7 @@ export class PlaybackService implements BasePlaybackService {
         }
 
         const tracksForPlaylist: TrackModels = await this.playlistService.getTracksAsync([playlistToPlay]);
-        this.enqueueAndPlayTracks(tracksForPlaylist.tracks, tracksForPlaylist.tracks[0]);
+        this.enqueueAndPlayTracks(tracksForPlaylist.tracks);
     }
 
     public async addTracksToQueueAsync(tracksToAdd: TrackModel[]): Promise<void> {

--- a/src/app/services/playback/queue.ts
+++ b/src/app/services/playback/queue.ts
@@ -18,6 +18,14 @@ export class Queue {
         return this._tracks.length;
     }
 
+    public getTracksInPlaybackOrder(): TrackModel[] {
+        let tracksInPlaybackOrder: TrackModel[] = [];
+        for (const trackIndex of this.playbackOrder) {
+            tracksInPlaybackOrder.push(this._tracks[trackIndex]);
+        }
+        return tracksInPlaybackOrder;
+    }
+
     public setTracks(tracksToSet: TrackModel[], shuffle: boolean): void {
         this._tracks = tracksToSet;
 


### PR DESCRIPTION
Have the `playbackQueue` in `PlaybackService` store the queue in playback order, so that the user can see the queue order in the playback queue component. Add method to `Queue` to get the playback order.

Also make `enqueueAndPlayTracks` choose the first track in the queue. This means that when enqueueing tracks from Album/Artist/Genre with shuffle on, it will start playback with a random track. Made a new method `enqueueAndPlayTracksFromDoubleClick`, used in the tracks collection and track browser components, which keeps the original functionality to start playback with the song that was double clicked, but shuffle the rest.

![playbackqueue-in-random-order](https://user-images.githubusercontent.com/18245360/229905610-9e58a53d-ec62-4e75-921c-8b6d5a7ffca5.png)

Because `enqueueAndPlayTracks` doesn't use the `trackToPlay` anymore, it has been removed from the method parameters, and the test checking for `"trackToPlay is undefined"` has been removed.

**Other test changes:**
Used a real `Queue` object instead of a mock, to properly test the shuffle functionality. Most changes to the tests are removing the mock setup and calling `enqueueAndPlayTracks` to get real results, using `spies` instead to test that the `Queue` methods are called, and adjusting the `enqueueAndPlayTracks` methods to use one argument. Some other test changes:
* loopMode tests make sure `currentTrack` is expected
* added a string builder to the shuffle checks to compare the queue to the given tracks and check that they are the same or different, depending on what is expected
* removed `"should not start playback if trackToPlay is undefined"` as that is no longer necessary
* some updates to `"playPrevious"` tests were needed since we aren't mocking the queue anymore or setting the `trackToPlay`. `"playPrevious"` will return `undefined` if a previous track wasn't playing, so we need to set it up by starting playback, then calling `"playNext"`. We can then call `"playPrevious"`. This means these tests might now be running assertions on different `trackModel` variables than before, depending on how the queue gets set up

**tests added:**
* `"should start playback with a random track if shuffle is on"` to `enqueueAndPlayArtists`, `enqueueAndPlayAlbum`, and `enqueueAndPlayGenre`. These tests use a loop to call each method multiple times if the shuffler happens to put the first track into first position (which would cause the test to fail).
* Added a test for `"playPrevious"` to check that it restarts the current track if playback lasted more than 3 seconds just because I noticed there wasn't one.