### PR TITLE
`fix` pt-BR non-translated string

### DIFF
--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -267,5 +267,5 @@
     "no-biography-found": "Não foi encontrada uma biografia",
     "show-welcome-screen-now": "Mostrar a tela de boas-vindas agora",
     "keep-playback-controls-visible-on-now-playing-page": "Manter os controles de reprodução visíveis na página de reprodução",
-    "open-folder": "Open folder"
+    "open-folder": "Abrir pasta",
 }


### PR DESCRIPTION
I have fixed and translated a string recently added to the application that had not yet been translated into **pt-BR**. In version **3.0.0-preview.23** of Dopamine.