### PR TITLE
fix #589 prevent toggle play via Space key when typing into an input

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -6,11 +6,9 @@ import { Logger } from './common/logger';
 import { IntegrationTestRunner } from './testing/integration-test-runner';
 import { EventListenerServiceBase } from './services/event-listener/event-listener.service.base';
 import { MediaSessionServiceBase } from './services/media-session/media-session.service.base';
-import { SearchServiceBase } from './services/search/search.service.base';
 import { TrayServiceBase } from './services/tray/tray.service.base';
 import { ScrobblingServiceBase } from './services/scrobbling/scrobbling.service.base';
 import { DiscordServiceBase } from './services/discord/discord.service.base';
-import { DialogServiceBase } from './services/dialog/dialog.service.base';
 import { TranslatorServiceBase } from './services/translator/translator.service.base';
 import { AppearanceServiceBase } from './services/appearance/appearance.service.base';
 import { NavigationServiceBase } from './services/navigation/navigation.service.base';
@@ -22,11 +20,9 @@ describe('AppComponent', () => {
     let navigationServiceMock: IMock<NavigationServiceBase>;
     let appearanceServiceMock: IMock<AppearanceServiceBase>;
     let translatorServiceMock: IMock<TranslatorServiceBase>;
-    let dialogServiceMock: IMock<DialogServiceBase>;
     let discordServiceMock: IMock<DiscordServiceBase>;
     let scrobblingServiceMock: IMock<ScrobblingServiceBase>;
     let trayServiceMock: IMock<TrayServiceBase>;
-    let searchServiceMock: IMock<SearchServiceBase>;
     let mediaSessionServiceMock: IMock<MediaSessionServiceBase>;
     let eventListenerServiceMock: IMock<EventListenerServiceBase>;
     let audioVisualizerMock: IMock<AudioVisualizer>;
@@ -46,11 +42,9 @@ describe('AppComponent', () => {
             navigationServiceMock.object,
             appearanceServiceMock.object,
             translatorServiceMock.object,
-            dialogServiceMock.object,
             discordServiceMock.object,
             scrobblingServiceMock.object,
             trayServiceMock.object,
-            searchServiceMock.object,
             mediaSessionServiceMock.object,
             eventListenerServiceMock.object,
             addToPlaylistMenuMock.object,
@@ -65,11 +59,9 @@ describe('AppComponent', () => {
         navigationServiceMock = Mock.ofType<NavigationServiceBase>();
         appearanceServiceMock = Mock.ofType<AppearanceServiceBase>();
         translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
-        dialogServiceMock = Mock.ofType<DialogServiceBase>();
         discordServiceMock = Mock.ofType<DiscordServiceBase>();
         scrobblingServiceMock = Mock.ofType<ScrobblingServiceBase>();
         trayServiceMock = Mock.ofType<TrayServiceBase>();
-        searchServiceMock = Mock.ofType<SearchServiceBase>();
         mediaSessionServiceMock = Mock.ofType<MediaSessionServiceBase>();
         eventListenerServiceMock = Mock.ofType<EventListenerServiceBase>();
         addToPlaylistMenuMock = Mock.ofType<AddToPlaylistMenu>();
@@ -222,13 +214,12 @@ describe('AppComponent', () => {
     });
 
     describe('handleKeyboardEvent', () => {
-        it('should prevent the default action when space is pressed while not searching and no input dialog is opened', () => {
+        it('should prevent the default action when space is pressed outside of an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keydown');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => false);
-            dialogServiceMock.setup((x) => x.isInputDialogOpened).returns(() => false);
             const app: AppComponent = createComponent();
 
             // Act
@@ -238,29 +229,12 @@ describe('AppComponent', () => {
             keyboardEventMock.verify((x) => x.preventDefault(), Times.once());
         });
 
-        it('should not prevent the default action when space is pressed while searching', () => {
+        it('should not prevent the default action when space is pressed inside an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keydown');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('input'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => true);
-            dialogServiceMock.setup((x) => x.isInputDialogOpened).returns(() => false);
-            const app: AppComponent = createComponent();
-
-            // Act
-            app.handleKeyboardEvent(keyboardEventMock.object);
-
-            // Assert
-            keyboardEventMock.verify((x) => x.preventDefault(), Times.never());
-        });
-
-        it('should not prevent the default action when space is pressed while an input dialog is opened', () => {
-            // Arrange
-            const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
-            keyboardEventMock.setup((x) => x.type).returns(() => 'keydown');
-            keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => false);
-            dialogServiceMock.setup((x) => x.isInputDialogOpened).returns(() => true);
             const app: AppComponent = createComponent();
 
             // Act
@@ -274,6 +248,7 @@ describe('AppComponent', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keydown');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => 'a');
             const app: AppComponent = createComponent();
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,11 +11,9 @@ import { AppConfig } from '../environments/environment';
 import { NavigationServiceBase } from './services/navigation/navigation.service.base';
 import { AppearanceServiceBase } from './services/appearance/appearance.service.base';
 import { TranslatorServiceBase } from './services/translator/translator.service.base';
-import { DialogServiceBase } from './services/dialog/dialog.service.base';
 import { DiscordServiceBase } from './services/discord/discord.service.base';
 import { ScrobblingServiceBase } from './services/scrobbling/scrobbling.service.base';
 import { TrayServiceBase } from './services/tray/tray.service.base';
-import { SearchServiceBase } from './services/search/search.service.base';
 import { MediaSessionServiceBase } from './services/media-session/media-session.service.base';
 import { EventListenerServiceBase } from './services/event-listener/event-listener.service.base';
 import { AddToPlaylistMenu } from './ui/components/add-to-playlist-menu';
@@ -34,11 +32,9 @@ export class AppComponent implements OnInit {
         private navigationService: NavigationServiceBase,
         private appearanceService: AppearanceServiceBase,
         private translatorService: TranslatorServiceBase,
-        private dialogService: DialogServiceBase,
         private discordService: DiscordServiceBase,
         private scrobblingService: ScrobblingServiceBase,
         private trayService: TrayServiceBase,
-        private searchService: SearchServiceBase,
         private mediaSessionService: MediaSessionServiceBase,
         private eventListenerService: EventListenerServiceBase,
         private addToPlaylistMenu: AddToPlaylistMenu,
@@ -55,7 +51,7 @@ export class AppComponent implements OnInit {
 
     @HostListener('document:keydown', ['$event'])
     public handleKeyboardEvent(event: KeyboardEvent): void {
-        if (event.key === ' ' && !this.searchService.isSearching && !this.dialogService.isInputDialogOpened) {
+        if (event.key === ' ' && !(event.target instanceof HTMLInputElement)) {
             // Prevents scrolling when pressing SPACE
             event.preventDefault();
         }

--- a/src/app/services/dialog/dialog.service.base.ts
+++ b/src/app/services/dialog/dialog.service.base.ts
@@ -1,7 +1,6 @@
 import { PlaylistModel } from '../playlist/playlist-model';
 
 export abstract class DialogServiceBase {
-    public abstract isInputDialogOpened: boolean;
     public abstract showConfirmationDialogAsync(dialogTitle: string, dialogText: string): Promise<boolean>;
     public abstract showInputDialogAsync(dialogTitle: string, placeHolderText: string, inputText: string): Promise<string>;
     public abstract showErrorDialog(errorText: string): void;

--- a/src/app/services/dialog/dialog.service.ts
+++ b/src/app/services/dialog/dialog.service.ts
@@ -21,8 +21,6 @@ export class DialogService implements DialogServiceBase {
         private playlistModelFactory: PlaylistModelFactory,
     ) {}
 
-    public isInputDialogOpened: boolean = false;
-
     public async showConfirmationDialogAsync(dialogTitle: string, dialogText: string): Promise<boolean> {
         const dialogRef: MatDialogRef<ConfirmationDialogComponent, boolean> = this.dialog.open(ConfirmationDialogComponent, {
             width: '450px',
@@ -39,8 +37,6 @@ export class DialogService implements DialogServiceBase {
     }
 
     public async showInputDialogAsync(dialogTitle: string, placeHolderText: string, inputText: string): Promise<string> {
-        this.isInputDialogOpened = true;
-
         const inputData: InputData = new InputData(dialogTitle, inputText, placeHolderText);
         const dialogRef: MatDialogRef<InputDialogComponent> = this.dialog.open(InputDialogComponent, {
             width: '450px',
@@ -48,8 +44,6 @@ export class DialogService implements DialogServiceBase {
         });
 
         await dialogRef.afterClosed().toPromise();
-
-        this.isInputDialogOpened = false;
 
         return inputData.inputText;
     }
@@ -68,8 +62,6 @@ export class DialogService implements DialogServiceBase {
     }
 
     public async showEditPlaylistDialogAsync(playlist: PlaylistModel): Promise<void> {
-        this.isInputDialogOpened = true;
-
         const playlistData = new PlaylistData(playlist);
         const dialogRef: MatDialogRef<EditPlaylistDialogComponent> = this.dialog.open(EditPlaylistDialogComponent, {
             width: '450px',
@@ -77,13 +69,9 @@ export class DialogService implements DialogServiceBase {
         });
 
         await dialogRef.afterClosed().toPromise();
-
-        this.isInputDialogOpened = false;
     }
 
     public async showCreatePlaylistDialogAsync(): Promise<void> {
-        this.isInputDialogOpened = true;
-
         const defaultPlaylist: PlaylistModel = this.playlistModelFactory.createDefault();
         const playlistData: PlaylistData = new PlaylistData(defaultPlaylist);
         const dialogRef: MatDialogRef<EditPlaylistDialogComponent> = this.dialog.open(EditPlaylistDialogComponent, {
@@ -92,8 +80,6 @@ export class DialogService implements DialogServiceBase {
         });
 
         await dialogRef.afterClosed().toPromise();
-
-        this.isInputDialogOpened = false;
     }
 
     public async showEditColumnsDialogAsync(): Promise<void> {

--- a/src/app/services/search/search.service.base.ts
+++ b/src/app/services/search/search.service.base.ts
@@ -2,8 +2,5 @@ export abstract class SearchServiceBase {
     public abstract searchText: string;
     public abstract delayedSearchText: string;
     public abstract hasSearchText: boolean;
-    public abstract isSearching: boolean;
-    public abstract startSearching(): void;
-    public abstract stopSearching(): void;
     public abstract matchesSearchText(originalText: string, searchText: string): boolean;
 }

--- a/src/app/services/search/search.service.spec.ts
+++ b/src/app/services/search/search.service.spec.ts
@@ -44,15 +44,6 @@ describe('SearchService', () => {
             // Assert
             expect(service.hasSearchText).toBeFalsy();
         });
-
-        it('should initialize isSearching as false', () => {
-            // Arrange
-
-            // Act
-
-            // Assert
-            expect(service.isSearching).toBeFalsy();
-        });
     });
 
     describe('hasSearchText', () => {
@@ -84,31 +75,6 @@ describe('SearchService', () => {
 
             // Assert
             expect(service.hasSearchText).toBeTruthy();
-        });
-    });
-
-    describe('startSearching', () => {
-        it('should set isSearching to true', () => {
-            // Arrange
-
-            // Act
-            service.startSearching();
-
-            // Assert
-            expect(service.isSearching).toBeTruthy();
-        });
-    });
-
-    describe('stopSearching', () => {
-        it('should set isSearching to false', () => {
-            // Arrange
-            service.startSearching();
-
-            // Act
-            service.stopSearching();
-
-            // Assert
-            expect(service.isSearching).toBeFalsy();
         });
     });
 

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -8,7 +8,6 @@ import { SearchServiceBase } from './search.service.base';
 @Injectable()
 export class SearchService implements SearchServiceBase {
     private updateDelayedSearchText: Subject<string> = new Subject<string>();
-    private _isSearching: boolean = false;
     private _searchText: string = '';
     private _delayedSearchText: string = '';
 
@@ -35,18 +34,6 @@ export class SearchService implements SearchServiceBase {
 
     public get hasSearchText(): boolean {
         return !StringUtils.isNullOrWhiteSpace(this.searchText);
-    }
-
-    public get isSearching(): boolean {
-        return this._isSearching;
-    }
-
-    public startSearching(): void {
-        this._isSearching = true;
-    }
-
-    public stopSearching(): void {
-        this._isSearching = false;
     }
 
     public matchesSearchText(originalText: string, searchText: string): boolean {

--- a/src/app/ui/components/collection/collection.component.spec.ts
+++ b/src/app/ui/components/collection/collection.component.spec.ts
@@ -114,12 +114,12 @@ describe('CollectionComponent', () => {
     });
 
     describe('handleKeyboardEvent', () => {
-        it('should toggle playback when space is pressed and while not searching', () => {
+        it('should toggle playback when space is pressed outside of an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => false);
             const component: CollectionComponent = createComponent();
 
             // Act
@@ -129,12 +129,12 @@ describe('CollectionComponent', () => {
             playbackServiceMock.verify((x) => x.togglePlayback(), Times.once());
         });
 
-        it('should not toggle playback when space is pressed and while searching', () => {
+        it('should not toggle playback when space is pressed inside an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('input'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => true);
             const component: CollectionComponent = createComponent();
 
             // Act
@@ -148,6 +148,7 @@ describe('CollectionComponent', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => 'a');
             const component: CollectionComponent = createComponent();
 

--- a/src/app/ui/components/collection/collection.component.ts
+++ b/src/app/ui/components/collection/collection.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, HostListener, ViewEncapsulation } from '@angular/core';
 import { AppearanceServiceBase } from '../../../services/appearance/appearance.service.base';
 import { PlaybackServiceBase } from '../../../services/playback/playback.service.base';
-import { SearchServiceBase } from '../../../services/search/search.service.base';
 import { SettingsBase } from '../../../common/settings/settings.base';
 import { AudioVisualizer } from '../../../services/playback/audio-visualizer';
 import { DocumentProxy } from '../../../common/io/document-proxy';
@@ -23,7 +22,6 @@ export class CollectionComponent extends AnimatedPage implements AfterViewInit {
         public collectionNavigationService: CollectionNavigationService,
         public settings: SettingsBase,
         private playbackService: PlaybackServiceBase,
-        private searchService: SearchServiceBase,
         private audioVisualizer: AudioVisualizer,
         private documentProxy: DocumentProxy,
     ) {
@@ -33,7 +31,7 @@ export class CollectionComponent extends AnimatedPage implements AfterViewInit {
 
     @HostListener('document:keyup', ['$event'])
     public handleKeyboardEvent(event: KeyboardEvent): void {
-        if (event.key === ' ' && !this.searchService.isSearching) {
+        if (event.key === ' ' && !(event.target instanceof HTMLInputElement)) {
             this.playbackService.togglePlayback();
         }
     }

--- a/src/app/ui/components/now-playing/now-playing.component.spec.ts
+++ b/src/app/ui/components/now-playing/now-playing.component.spec.ts
@@ -40,7 +40,6 @@ describe('NowPlayingComponent', () => {
             navigationServiceMock.object,
             metadataServiceMock.object,
             playbackServiceMock.object,
-            searchServiceMock.object,
             nowPlayingNavigationServiceMock.object,
             schedulerMock.object,
             audioVisualizerMock.object,
@@ -54,7 +53,6 @@ describe('NowPlayingComponent', () => {
         navigationServiceMock = Mock.ofType<NavigationServiceBase>();
         metadataServiceMock = Mock.ofType<MetadataServiceBase>();
         playbackServiceMock = Mock.ofType<PlaybackServiceBase>();
-        searchServiceMock = Mock.ofType<SearchServiceBase>();
         nowPlayingNavigationServiceMock = Mock.ofType<NowPlayingNavigationServiceBase>();
         schedulerMock = Mock.ofType<SchedulerBase>();
         audioVisualizerMock = Mock.ofType<AudioVisualizer>();
@@ -634,12 +632,12 @@ describe('NowPlayingComponent', () => {
     });
 
     describe('handleKeyboardEvent', () => {
-        it('should toggle playback when space is pressed and while not searching', () => {
+        it('should toggle playback when space is pressed outside of an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => false);
             const component: NowPlayingComponent = createComponent();
 
             // Act
@@ -649,12 +647,12 @@ describe('NowPlayingComponent', () => {
             playbackServiceMock.verify((x) => x.togglePlayback(), Times.once());
         });
 
-        it('should not toggle playback when space is pressed and while searching', () => {
+        it('should not toggle playback when space is pressed inside an input element', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('input'));
             keyboardEventMock.setup((x) => x.key).returns(() => ' ');
-            searchServiceMock.setup((x) => x.isSearching).returns(() => true);
             const component: NowPlayingComponent = createComponent();
 
             // Act
@@ -668,6 +666,7 @@ describe('NowPlayingComponent', () => {
             // Arrange
             const keyboardEventMock: IMock<KeyboardEvent> = Mock.ofType<KeyboardEvent>();
             keyboardEventMock.setup((x) => x.type).returns(() => 'keyup');
+            keyboardEventMock.setup((x) => x.target).returns(() => document.createElement('div'));
             keyboardEventMock.setup((x) => x.key).returns(() => 'a');
             const component: NowPlayingComponent = createComponent();
 

--- a/src/app/ui/components/now-playing/now-playing.component.ts
+++ b/src/app/ui/components/now-playing/now-playing.component.ts
@@ -7,7 +7,6 @@ import { AppearanceServiceBase } from '../../../services/appearance/appearance.s
 import { NavigationServiceBase } from '../../../services/navigation/navigation.service.base';
 import { MetadataServiceBase } from '../../../services/metadata/metadata.service.base';
 import { PlaybackServiceBase } from '../../../services/playback/playback.service.base';
-import { SearchServiceBase } from '../../../services/search/search.service.base';
 import { NowPlayingNavigationServiceBase } from '../../../services/now-playing-navigation/now-playing-navigation.service.base';
 import { SchedulerBase } from '../../../common/scheduling/scheduler.base';
 import { AudioVisualizer } from '../../../services/playback/audio-visualizer';
@@ -98,7 +97,6 @@ export class NowPlayingComponent extends AnimatedPage implements OnInit, AfterVi
         private navigationService: NavigationServiceBase,
         private metadataService: MetadataServiceBase,
         private playbackService: PlaybackServiceBase,
-        private searchService: SearchServiceBase,
         private nowPlayingNavigationService: NowPlayingNavigationServiceBase,
         private scheduler: SchedulerBase,
         private audioVisualizer: AudioVisualizer,
@@ -119,7 +117,7 @@ export class NowPlayingComponent extends AnimatedPage implements OnInit, AfterVi
 
     @HostListener('document:keyup', ['$event'])
     public handleKeyboardEvent(event: KeyboardEvent): void {
-        if (event.key === ' ' && !this.searchService.isSearching) {
+        if (event.key === ' ' && !(event.target instanceof HTMLInputElement)) {
             this.playbackService.togglePlayback();
         }
     }

--- a/src/app/ui/components/search-box/search-box.component.html
+++ b/src/app/ui/components/search-box/search-box.component.html
@@ -1,5 +1,5 @@
-<div class="app-search-box" [ngClass]="{ 'app-search-box-highlight': this.searchService.isSearching || this.searchService.hasSearchText }">
-    <input class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" (blur)="onBlur()" (focus)="onFocus()" />
+<div class="app-search-box" [ngClass]="{ 'app-search-box-highlight': this.searchService.hasSearchText }">
+    <input class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" />
     <div class="app-search-box__icons">
         <i class="las la-search app-search-box-icon" *ngIf="!this.searchService.hasSearchText"></i>
         <i class="las la-times app-search-box-icon pointer" *ngIf="this.searchService.hasSearchText" (click)="clearSearchText()"></i>

--- a/src/app/ui/components/search-box/search-box.component.scss
+++ b/src/app/ui/components/search-box/search-box.component.scss
@@ -11,6 +11,7 @@
     transition: all 0.25s ease 0s;
 }
 
+.app-search-box:focus-within,
 .app-search-box-highlight {
     transition: all 0.15s ease 0s;
     border: 1px solid var(--theme-accent-color);

--- a/src/app/ui/components/search-box/search-box.component.spec.ts
+++ b/src/app/ui/components/search-box/search-box.component.spec.ts
@@ -31,30 +31,6 @@ describe('SearchBoxComponent', () => {
         });
     });
 
-    describe('onBlur', () => {
-        it('should stop searching', () => {
-            // Arrange
-
-            // Act
-            component.onBlur();
-
-            // Assert
-            searchServiceMock.verify((x) => x.stopSearching(), Times.once());
-        });
-    });
-
-    describe('onFocus', () => {
-        it('should start searching', () => {
-            // Arrange
-
-            // Act
-            component.onFocus();
-
-            // Assert
-            searchServiceMock.verify((x) => x.startSearching(), Times.once());
-        });
-    });
-
     describe('clearSearchText', () => {
         it('should clear the search text', () => {
             // Arrange

--- a/src/app/ui/components/search-box/search-box.component.ts
+++ b/src/app/ui/components/search-box/search-box.component.ts
@@ -11,14 +11,6 @@ import { SearchServiceBase } from '../../../services/search/search.service.base'
 export class SearchBoxComponent {
     public constructor(public searchService: SearchServiceBase) {}
 
-    public onBlur(): void {
-        this.searchService.stopSearching();
-    }
-
-    public onFocus(): void {
-        this.searchService.startSearching();
-    }
-
     public clearSearchText(): void {
         this.searchService.searchText = '';
     }


### PR DESCRIPTION
Prevents toogling play/pause when 'Space' key is pressed and an input is the event target.

The two flags in the DialogService and SearchService were removed because they were no longer needed. I am not sure if those will be needed in the future (I can re-add those if you  want). For now there  was only one more usages besides the "Space key press" which is the focus styling of the search box. That could be solved by `:focus-within`.