### PR TITLE
fixes preload bug

### DIFF
--- a/src/app/services/playback/playback.service.ts
+++ b/src/app/services/playback/playback.service.ts
@@ -407,6 +407,9 @@ export class PlaybackService {
                 clearTimeout(this._preloadTimeoutId);
             }
             this._preloadTimeoutId = setTimeout(() => {
+                if (!this._nextTrack) {
+                    return; // no next track
+                }
                 this._audioPlayer.preloadNextTrack(this._nextTrack!.path);
                 this.logger.info(`Preloaded '${this._nextTrack!.path}'`, 'PlaybackService', 'preloadNextTrackAfterDelay');
             }, 2000);


### PR DESCRIPTION
Now if the next track doesn't exist ( on end of the playlist) an app won't try to preload undefined

error log:
[GlobalErrorHandler] [handleError]  Handling global error. Error: Cannot read properties of undefined (reading 'path')


Also tested this branch for issue/715 bugs. Everything seem to work fine
Media controls work as expected and gapless playback doesn't cause issues on MacOS with wireless headphones.

One minor thing: If song doesn't have an album cover then system will show album cover of previous played song.
