### PR TITLE
Show album cover in macOS Dock.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -295,6 +295,7 @@ import { CoverPlayerPlaybackQueueComponent } from './ui/components/mini-players/
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { CoverPlayerVolumeControlComponent } from './ui/components/mini-players/cover-player/cover-player-volume-control/cover-player-volume-control.component';
 import { VolumeIconComponent } from './ui/components/volume-icon/volume-icon.component';
+import { MacOSDockService } from './services/dock/macos.dock.service';
 
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -486,7 +487,7 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
         {
             provide: APP_INITIALIZER,
             useFactory: appInitializerFactory,
-            deps: [TranslateService, Injector],
+            deps: [TranslateService, Injector, MacOSDockService],
             multi: true,
         },
         ElectronService,

--- a/src/app/common/settings/settings.base.ts
+++ b/src/app/common/settings/settings.base.ts
@@ -59,6 +59,7 @@ export abstract class SettingsBase {
     public abstract showPlaylistsPage: boolean;
     public abstract showFoldersPage: boolean;
     public abstract showRating: boolean;
+    public abstract showAlbumCoverInDock: boolean;
     public abstract saveRatingToAudioFiles: boolean;
     public abstract tracksPageVisibleColumns: string;
     public abstract tracksPageColumnsOrder: string;

--- a/src/app/common/settings/settings.ts
+++ b/src/app/common/settings/settings.ts
@@ -570,6 +570,15 @@ export class Settings implements SettingsBase {
         this.settings.set('showRating', v);
     }
 
+    // showAlbumCoverInDock
+    public get showAlbumCoverInDock(): boolean {
+        return <boolean>this.settings.get('showAlbumCoverInDock');
+    }
+
+    public set showAlbumCoverInDock(v: boolean) {
+        this.settings.set('showAlbumCoverInDock', v);
+    }
+
     // tracksPageVisibleColumns
     public get tracksPageVisibleColumns(): string {
         return <string>this.settings.get('tracksPageVisibleColumns');
@@ -1017,6 +1026,10 @@ export class Settings implements SettingsBase {
 
         if (!this.settings.has('showRating')) {
             this.settings.set('showRating', true);
+        }
+
+        if (!this.settings.has('showAlbumCoverInDock')) {
+            this.settings.set('showAlbumCoverInDock', false);
         }
 
         if (!this.settings.has('saveRatingToAudioFiles')) {

--- a/src/app/services/appearance/appearance.service.base.ts
+++ b/src/app/services/appearance/appearance.service.base.ts
@@ -12,6 +12,7 @@ export abstract class AppearanceServiceBase {
     public abstract fontSizes: number[];
     public abstract themes: Theme[];
     public abstract followSystemTheme: boolean;
+    public abstract showAlbumCoverInDock: boolean;
     public abstract useLightBackgroundTheme: boolean;
     public abstract followSystemColor: boolean;
     public abstract followAlbumCoverColor: boolean;

--- a/src/app/services/appearance/appearance.service.ts
+++ b/src/app/services/appearance/appearance.service.ts
@@ -514,9 +514,8 @@ export class AppearanceService implements AppearanceServiceBase {
         try {
             const track = this.playbackService.currentTrack;
             if (this.settings.showAlbumCoverInDock && this.application.getGlobal('isMacOS') && track != undefined) {
-                const albumArtworkPath: string = this.metadataService.getAlbumArtworkPath(track.albumKey);
-                const image = nativeImage.createFromPath(albumArtworkPath);
-                remote.app.dock.setIcon(image);
+                const albumArtwork = await this.metadataService.getDockAlbumArtwork(track.albumKey);
+                remote.app.dock.setIcon(albumArtwork);
                 
             } else {
                 const staticPath = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\');

--- a/src/app/services/dock/macos.dock.service.base.ts
+++ b/src/app/services/dock/macos.dock.service.base.ts
@@ -1,0 +1,5 @@
+import { Menu } from "electron";
+
+export abstract class MacOSDockServiceBase {
+    public abstract reloadDockMenu(): void;
+}

--- a/src/app/services/dock/macos.dock.service.ts
+++ b/src/app/services/dock/macos.dock.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { MacOSDockServiceBase } from './macos.dock.service.base';
+import { Menu } from 'electron';
+import * as remote from '@electron/remote';
+import { Subscription } from 'rxjs';
+import { TranslatorServiceBase } from '../translator/translator.service.base';
+import { PlaybackService } from '../playback/playback.service';
+import { Logger } from '../../common/logger';
+
+@Injectable({ providedIn: 'root' })
+export class MacOSDockService implements MacOSDockServiceBase {
+    private dockMenu: Menu;
+    private subscription: Subscription = new Subscription();
+
+    constructor (
+        private translatorService: TranslatorServiceBase,
+        private playbackService: PlaybackService,
+        private logger: Logger,
+    ) {
+        this.logger.info('Init service', MacOSDockService.name, 'constructor');
+        this.initializeSubscriptions();
+    }
+
+    private initializeSubscriptions(): void {
+        this.subscription.add(
+            this.translatorService.languageChanged$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+        this.subscription.add(
+            this.playbackService.playbackStarted$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+        this.subscription.add(
+            this.playbackService.playbackPaused$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+        this.subscription.add(
+            this.playbackService.playbackResumed$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+        this.subscription.add(
+            this.playbackService.playbackStopped$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+        this.subscription.add(
+            this.playbackService.playbackSkipped$.subscribe(() => {
+                this.reloadDockMenu();
+            }),
+        );
+    }
+
+    public getDockMenu(): Menu {
+        return this.dockMenu;
+    }
+
+    public reloadDockMenu(): void {
+        this.logger.info(`Reloading dock menu: ${this.playbackService.isPlaying}`, MacOSDockService.name, 'reloadDockMenu');
+        const menu = new remote.Menu();
+        if (this.playbackService.isPlaying) {
+            menu.append(new remote.MenuItem({ label: this.translatorService.get('pause'), click: () => this.playbackService.togglePlayback() }));
+        } else {
+            menu.append(new remote.MenuItem({ label: this.translatorService.get('play'), click: () => this.playbackService.togglePlayback() }));
+        }
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('previous'), click: () => this.playbackService.playPrevious() }));
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('next'), click: () => this.playbackService.playNext() }));
+        remote.app.dock.setMenu(menu);
+        this.dockMenu = menu;
+    }
+}

--- a/src/app/services/media-session/media-session.service.ts
+++ b/src/app/services/media-session/media-session.service.ts
@@ -3,7 +3,10 @@ import { PlaybackInformation } from '../playback-information/playback-informatio
 import { MediaSessionProxy } from '../../common/io/media-session-proxy';
 import { TrackModel } from '../track/track-model';
 import { Observable, Subject } from 'rxjs';
+import * as remote from '@electron/remote';
 import { PlaybackInformationFactory } from '../playback-information/playback-information.factory';
+import { TranslatorServiceBase } from '../translator/translator.service.base';
+import { Menu } from 'electron';
 
 @Injectable({ providedIn: 'root' })
 export class MediaSessionService {
@@ -15,6 +18,7 @@ export class MediaSessionService {
     public constructor(
         private playbackInformationFactory: PlaybackInformationFactory,
         private mediaSessionProxy: MediaSessionProxy,
+        private translatorService: TranslatorServiceBase,
     ) {}
 
     public playEvent$: Observable<void> = this.playEvent.asObservable();
@@ -39,4 +43,14 @@ export class MediaSessionService {
             playbackInformation.imageUrl,
         );
     }
+
+    public getDockMenu(): Menu {
+        const menu = new remote.Menu();
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('play'), click: () => this.playEvent.next() }));
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('pause'), click: () => this.pauseEvent.next() }));
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('previous'), click: () => this.previousTrackEvent.next() }));
+        menu.append(new remote.MenuItem({ label: this.translatorService.get('next'), click: () => this.nextTrackEvent.next() }));
+        return menu;
+    }
+
 }

--- a/src/app/services/media-session/media-session.service.ts
+++ b/src/app/services/media-session/media-session.service.ts
@@ -3,10 +3,7 @@ import { PlaybackInformation } from '../playback-information/playback-informatio
 import { MediaSessionProxy } from '../../common/io/media-session-proxy';
 import { TrackModel } from '../track/track-model';
 import { Observable, Subject } from 'rxjs';
-import * as remote from '@electron/remote';
 import { PlaybackInformationFactory } from '../playback-information/playback-information.factory';
-import { TranslatorServiceBase } from '../translator/translator.service.base';
-import { Menu } from 'electron';
 
 @Injectable({ providedIn: 'root' })
 export class MediaSessionService {
@@ -18,7 +15,6 @@ export class MediaSessionService {
     public constructor(
         private playbackInformationFactory: PlaybackInformationFactory,
         private mediaSessionProxy: MediaSessionProxy,
-        private translatorService: TranslatorServiceBase,
     ) {}
 
     public playEvent$: Observable<void> = this.playEvent.asObservable();
@@ -43,14 +39,4 @@ export class MediaSessionService {
             playbackInformation.imageUrl,
         );
     }
-
-    public getDockMenu(): Menu {
-        const menu = new remote.Menu();
-        menu.append(new remote.MenuItem({ label: this.translatorService.get('play'), click: () => this.playEvent.next() }));
-        menu.append(new remote.MenuItem({ label: this.translatorService.get('pause'), click: () => this.pauseEvent.next() }));
-        menu.append(new remote.MenuItem({ label: this.translatorService.get('previous'), click: () => this.previousTrackEvent.next() }));
-        menu.append(new remote.MenuItem({ label: this.translatorService.get('next'), click: () => this.nextTrackEvent.next() }));
-        return menu;
-    }
-
 }

--- a/src/app/services/playback/playback.service.ts
+++ b/src/app/services/playback/playback.service.ts
@@ -416,10 +416,9 @@ export class PlaybackService {
         this.preloadNextTrackAfterDelay();
     }
 
-    private showDockAlbumArtwork(track: TrackModel): void {
-        const albumArtworkPath: string = this.metadataService.getAlbumArtworkPath(track.albumKey);
-        const image = nativeImage.createFromPath(albumArtworkPath);
-        remote.app.dock.setIcon(image);
+    private async showDockAlbumArtwork(track: TrackModel): Promise<void> {
+        const albumArtwork = await this.metadataService.getDockAlbumArtwork(track.albumKey);
+        remote.app.dock.setIcon(albumArtwork);
     }
 
     private preloadNextTrackAfterDelay(): void {

--- a/src/app/testing/settings-mock.ts
+++ b/src/app/testing/settings-mock.ts
@@ -70,6 +70,7 @@ export class SettingsMock implements SettingsBase {
     public showRating: boolean;
     public showTracksPage: boolean;
     public showWelcome: boolean;
+    public showAlbumCoverInDock: boolean;
     public skipRemovedFilesDuringRefresh: boolean;
     public theme: string;
     public tracksPageColumnsOrder: string;

--- a/src/app/ui/components/settings/appearance-settings/appearance-settings.component.html
+++ b/src/app/ui/components/settings/appearance-settings/appearance-settings.component.html
@@ -41,6 +41,9 @@
     <div class="title">{{ 'title-bar' | translate }}</div>
     <app-toggle-switch [(isChecked)]="settings.useSystemTitleBar"> {{ 'use-system-title-bar' | translate }}</app-toggle-switch>
     <mat-divider class="my-4"></mat-divider>
+    <div class="title">{{ 'dock-bar' | translate }}</div>
+    <app-toggle-switch [(isChecked)]="appearanceService.showAlbumCoverInDock"> {{ 'show-album-cover-in-dock' | translate }}</app-toggle-switch>
+    <mat-divider class="my-4"></mat-divider>
     <div class="title">{{ 'language' | translate }}</div>
     <div>{{ 'choose-language' | translate }}</div>
     <mat-form-field class="mt-2">

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -38,6 +38,8 @@
     "follow-system-color": "Follow the system color",
     "title-bar": "Title bar",
     "use-system-title-bar": "Use system title bar (requires a restart)",
+    "dock-bar": "Dock",
+    "show-album-cover-in-dock": "Show album cover as the Dock icon (macOS only)",
     "choose-language": "Choose a language",
     "text-size": "Text size",
     "choose-text-size": "Choose a text size",


### PR DESCRIPTION
Added an option to set the macOS dock icon to the album cover of the current track.
I'm not sure how to handle the other platform, also I'm not familiar with Electron.