### PR TITLE
Add search shortcuts

### DIFF
--- a/src/app/ui/components/search-box/search-box.component.html
+++ b/src/app/ui/components/search-box/search-box.component.html
@@ -1,5 +1,5 @@
 <div class="app-search-box" [ngClass]="{ 'app-search-box-highlight': this.searchService.hasSearchText }">
-    <input class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" />
+    <input id="app-search-box" class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" />
     <div class="app-search-box__icons">
         <i class="las la-search app-search-box-icon" *ngIf="!this.searchService.hasSearchText"></i>
         <i class="las la-times app-search-box-icon pointer" *ngIf="this.searchService.hasSearchText" (click)="clearSearchText()"></i>

--- a/src/app/ui/components/search-box/search-box.component.spec.ts
+++ b/src/app/ui/components/search-box/search-box.component.spec.ts
@@ -42,4 +42,313 @@ describe('SearchBoxComponent', () => {
             searchServiceMock.verify((x) => (x.searchText = ''), Times.once());
         });
     });
+
+    describe('handleKeyboardEvent', () => {
+        const appSearchBoxId = 'app-search-box';
+
+        afterEach(() => {
+            const appSearchBox = document.getElementById(appSearchBoxId);
+            if (appSearchBox) {
+                document.body.removeChild(appSearchBox);
+            }
+        });
+
+        it(`should blur #${appSearchBoxId} input on Escape key press`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                key: 'Escape',
+            });
+            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+            expect(blurSpy).toHaveBeenCalledTimes(1);
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not blur #${appSearchBoxId} input on not Escape key press`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                key: 'a',
+            });
+            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not blur other inputs on Escape key press', () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = 'other-input';
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                key: 'Escape',
+            });
+            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+
+            document.body.removeChild(appSearchBox);
+        });
+
+        it(`should focus #${appSearchBoxId} input on Ctrl+KeyF`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: false,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it(`should focus #${appSearchBoxId} input on Meta+KeyF (macOS)`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: false,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Ctrl+KeyF if target is #${appSearchBoxId}`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: false,
+            });
+            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Meta+KeyF (macOS) if target is #${appSearchBoxId}`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: false,
+            });
+            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Ctrl+Shift+KeyF`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Meta+Shift+KeyF (macOS)`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Ctrl+non-KeyF`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyA',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: false,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on Meta+non-KeyF (macOS)`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyA',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: false,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should not focus #${appSearchBoxId} input on KeyF`, () => {
+            // Arrange
+            const appSearchBox = document.createElement('input');
+            appSearchBox.id = appSearchBoxId;
+            document.body.appendChild(appSearchBox);
+            const blurSpy = jest.spyOn(appSearchBox, 'blur');
+            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: false,
+                shiftKey: false,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            expect(blurSpy).not.toHaveBeenCalled();
+            expect(focusSpy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/app/ui/components/search-box/search-box.component.ts
+++ b/src/app/ui/components/search-box/search-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, HostListener, ViewEncapsulation } from '@angular/core';
 import { SearchServiceBase } from '../../../services/search/search.service.base';
 
 @Component({
@@ -10,6 +10,27 @@ import { SearchServiceBase } from '../../../services/search/search.service.base'
 })
 export class SearchBoxComponent {
     public constructor(public searchService: SearchServiceBase) {}
+
+    private readonly _searchBoxId = 'app-search-box';
+
+    @HostListener('document:keydown', ['$event'])
+    public handleKeyboardEvent(event: KeyboardEvent): void {
+        if (event.target instanceof HTMLInputElement && event.target.id === this._searchBoxId) {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                event.target.blur();
+            }
+            return;
+        }
+
+        if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.code === 'KeyF') {
+            const appSearchBox = document.getElementById(this._searchBoxId);
+            if (appSearchBox) {
+                event.preventDefault();
+                (<HTMLInputElement>appSearchBox).focus();
+            }
+        }
+    }
 
     public clearSearchText(): void {
         this.searchService.searchText = '';


### PR DESCRIPTION
- On `Ctrl / Meta(macOS)` + `KeyF` the app's search is focused
- On `Esc` within the search it is `blurred (unfocused)`
- Tested only on `Windows 10`, but according to [the doc](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent), it should work on `macOS` as well