### PR TITLE
Fixes #744: Folder names need ellipsis

### DIFF
--- a/src/app/ui/components/collection/collection-folders/collection-folders.component.html
+++ b/src/app/ui/components/collection/collection-folders/collection-folders.component.html
@@ -67,7 +67,7 @@
             <div class="h-100 d-flex flex-column p-3">
                 <div class="d-flex flex-row flex-wrap mb-3">
                     <app-transparent-button
-                        class="mr-2 mb-2"
+                        class="mr-2 mb-2 fit-width"
                         *ngFor="let subfolderBreadcrumb of subfolderBreadcrumbs"
                         (click)="setOpenedSubfolderAsync(subfolderBreadcrumb)"
                     >

--- a/src/app/ui/components/collection/collection-folders/collection-folders.component.scss
+++ b/src/app/ui/components/collection/collection-folders/collection-folders.component.scss
@@ -1,3 +1,13 @@
+.fit-width {
+    width: fit-content;
+    max-width: 100%;
+}
+
+.fit-width * {
+    width: inherit;
+    max-width: inherit;
+}
+
 .subfolder {
     height: 30px;
 }

--- a/src/app/ui/components/controls/transparent-button/transparent-button.component.html
+++ b/src/app/ui/components/controls/transparent-button/transparent-button.component.html
@@ -1,5 +1,7 @@
 <div class="app-transparent-button-wrap">
     <div class="app-transparent-button-button" [ngClass]="{ 'w-100': this.fill }">
-        <ng-content></ng-content>
+        <span class="app-transparent-button-text ellipsis">
+            <ng-content></ng-content>
+        </span>
     </div>
 </div>

--- a/src/app/ui/components/controls/transparent-button/transparent-button.component.scss
+++ b/src/app/ui/components/controls/transparent-button/transparent-button.component.scss
@@ -24,6 +24,11 @@
     font-size: calc(var(--fontsize) * 0.8);
 }
 
+.app-transparent-button-text {
+    flex: 1;
+    min-width: 0;
+}
+
 .app-transparent-button-button:hover {
     background-color: var(--theme-accent-color);
     box-shadow: 0 5px 15px rgba(var(--theme-rgb-accent), 0.4);


### PR DESCRIPTION
- From the ticket (#744) I found only one issue that persists: when a folder name is too long to fit right panel and it overflows.
- I wrapped `app-transparent-button-button` content which is always text, afaik, to apply ellipsis, because `app-transparent-button-button` is flex and it doesn't work properly with ellipsis
- There should not be a regression in the button regard, but I haven't checked every single one

<details>
<summary>Before</summary>

![before-right-bug-3](https://github.com/user-attachments/assets/f0a284b7-16e3-42e7-8f3e-6de62f884711)
</details>


<details>
<summary>After</summary>

![after-right-ok-3](https://github.com/user-attachments/assets/203b5856-d818-487f-a525-dd18ef1fd89c)
</details>

