### PR TITLE
Order albums on empty albums change

### DIFF
--- a/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
@@ -9,7 +9,6 @@ import { ApplicationServiceBase } from '../../../../services/application/applica
 import { NativeElementProxy } from '../../../../common/native-element-proxy';
 import { TranslatorServiceBase } from '../../../../services/translator/translator.service.base';
 import { MouseSelectionWatcher } from '../../mouse-selection-watcher';
-import { FileAccess } from '../../../../common/io/file-access';
 import { Logger } from '../../../../common/logger';
 import { ContextMenuOpener } from '../../context-menu-opener';
 import { AlbumData } from '../../../../data/entities/album-data';
@@ -232,30 +231,7 @@ describe('AlbumBrowserComponent', () => {
             albumRowsGetterMock.verify((x) => x.getAlbumRows(It.isAny(), It.isAny(), It.isAny()), Times.never());
         });
 
-        it('should not order the albums given changes for albumsPersister and albums if albums is undefined and albumsPersister is not undefined', () => {
-            // Arrange
-            const albumData1: AlbumData = new AlbumData();
-            const albumData2: AlbumData = new AlbumData();
-            const album1: AlbumModel = new AlbumModel(albumData1, translatorServiceMock.object, applicationPathsMock.object);
-            const album2: AlbumModel = new AlbumModel(albumData2, translatorServiceMock.object, applicationPathsMock.object);
-            const albums: AlbumModel[] = [album1, album2];
-            nativeElementProxyMock.setup((x) => x.getElementWidth(It.isAny())).returns(() => 500);
-            const component: AlbumBrowserComponent = createComponent();
-            albumsPersisterMock.setup((x) => x.getSelectedAlbumOrder()).returns(() => AlbumOrder.byAlbumArtist);
-            component.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
-            component.albumsPersister = albumsPersisterMock.object;
-
-            const albumsPersisterChanges: any = { albumsPersister: { currentValue: albumsPersisterMock.object } };
-            const albumsChanges: any = { albums: { currentValue: albums } };
-
-            // Act
-            component.ngOnChanges({ albumsPersister: albumsPersisterChanges, albums: albumsChanges });
-
-            // Assert
-            albumRowsGetterMock.verify((x) => x.getAlbumRows(It.isAny(), It.isAny(), It.isAny()), Times.never());
-        });
-
-        it('should not order the albums given changes for albumsPersister and albums if albums and albumsPersister are not undefined and albums is empty', () => {
+        it('should order the albums given changes for albumsPersister and albums if albums and albumsPersister are not undefined and albums is empty', () => {
             // Arrange
             const albumData1: AlbumData = new AlbumData();
             const albumData2: AlbumData = new AlbumData();
@@ -276,7 +252,7 @@ describe('AlbumBrowserComponent', () => {
             component.ngOnChanges({ albumsPersister: albumsPersisterChanges, albums: albumsChanges });
 
             // Assert
-            albumRowsGetterMock.verify((x) => x.getAlbumRows(It.isAny(), It.isAny(), It.isAny()), Times.never());
+            albumRowsGetterMock.verify((x) => x.getAlbumRows(It.isAny(), It.isAny(), It.isAny()), Times.once());
         });
 
         it('should order the albums given changes for albumsPersister and albums if albums is not undefined and not empty and albumsPersister is undefined', () => {

--- a/src/app/ui/components/collection/album-browser/album-browser.component.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.ts
@@ -48,7 +48,7 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
 
     public ngOnChanges(changes: SimpleChanges): void {
         if (changes['albums'] || changes['albumsPersister']) {
-            if (this.albums && this.albums.length > 0 && this.albumsPersister) {
+            if (this.albums && this.albumsPersister) {
                 this.orderAlbums();
             }
         }


### PR DESCRIPTION
There is an issue in tabs `ARTISTS/GENRES/ALBUMS` (where `app-album-browser` is used):
1. `AlbumBrowserComponent#albumRows` contains actual data
2. on the UI search for something that results in empty albums and set it
3. `AlbumBrowserComponent#ngOnChanges` does not call `AlbumBrowserComponent#orderAlbums` when `albums` is empty
4. `AlbumBrowserComponent#albumRows` is not refreshed and we see the stale data

To fix that we need to call `AlbumBrowserComponent#orderAlbums` when `albums` is empty as well.