### PR TITLE
Reset progress on playback stop

### DIFF
--- a/src/app/services/playback/playback.service.ts
+++ b/src/app/services/playback/playback.service.ts
@@ -628,7 +628,8 @@ export class PlaybackService {
 
     public stopUpdatingProgress(): void {
         this.pauseUpdatingProgress();
-        this.progressChanged.next(new PlaybackProgress(0, 0));
+        this._progress = new PlaybackProgress(0, 0);
+        this.progressChanged.next(this._progress);
     }
 
     public pauseUpdatingProgress(): void {


### PR DESCRIPTION
Current version displays a stale progress after the playback stop, so we need to reset it properly and show `0:00/0:00`.

![image](https://github.com/user-attachments/assets/e322d18d-d3b5-4769-add8-cbee54d92f6a)
