### PR TITLE
Fixes #685. Do not filter tracks on Albums tab

### DIFF
--- a/src/app/ui/components/collection/collection-albums/collection-albums.component.html
+++ b/src/app/ui/components/collection/collection-albums/collection-albums.component.html
@@ -11,7 +11,7 @@
             ><div class="right-side-pane">
                 <app-track-browser
                     class="p-3 fill"
-                    [tracks]="this.tracks | tracksFilter: this.searchService.delayedSearchText"
+                    [tracks]="this.tracks"
                     [(tracksPersister)]="this.tracksPersister"
                 ></app-track-browser></div
         ></as-split-area>


### PR DESCRIPTION
As a user, searching on the `ALBUMS` tab I expect only albums to be affected, whereas tracks are not filtered and are shown as is for resulting albums.

My proposal is to remove tracks  filtering on the tab.

<details>
<summary>Before</summary>

![albums-search-before](https://github.com/user-attachments/assets/56a2d17d-c25f-4db7-a552-466ce65ba300)
</details>

<details>
<summary>After</summary>

![albums-search-after](https://github.com/user-attachments/assets/f4c133e3-2bf8-4fed-872d-b0744cd030b8)
</details>
