### PR TITLE
Enhancement: Support getting LRC lyrics from a "Lyrics" subfolder

### DIFF
--- a/src/app/services/lyrics/lrc-lyrics-getter.ts
+++ b/src/app/services/lyrics/lrc-lyrics-getter.ts
@@ -41,23 +41,19 @@ export class LrcLyricsGetter implements ILyricsGetter {
     }
 
     private getLrcFilePath(track: TrackModel): string {
-        const trackPathWithoutExtension: string = this.fileAccess.getPathWithoutExtension(track.path);
-        let possibleLrcFilePath: string = `${trackPathWithoutExtension}.lrc`;
+        const trackPath: string = this.fileAccess.getDirectoryPath(track.path);
+        const trackFileNameWithoutExtension: string = this.fileAccess.getFileNameWithoutExtension(track.path);
+        const lrcExtensions: string[] = ['.lrc', '.Lrc', '.LRC']
+        const possibleFolders: string[] = [`${trackPath}`, `${trackPath}\\lyrics`, `${trackPath}\\Lyrics`, `${trackPath}\\LYRICS`]
 
-        if (this.fileAccess.pathExists(possibleLrcFilePath)) {
-            return possibleLrcFilePath;
-        }
+        for (var folder of possibleFolders) {
+            for (var ext of lrcExtensions) {
+                let possibleLrcFilePath: string = `${folder}\\${trackFileNameWithoutExtension}${ext}`;
 
-        possibleLrcFilePath = `${trackPathWithoutExtension}.Lrc`;
-
-        if (this.fileAccess.pathExists(possibleLrcFilePath)) {
-            return possibleLrcFilePath;
-        }
-
-        possibleLrcFilePath = `${trackPathWithoutExtension}.LRC`;
-
-        if (this.fileAccess.pathExists(possibleLrcFilePath)) {
-            return possibleLrcFilePath;
+                if (this.fileAccess.pathExists(possibleLrcFilePath)) {
+                    return possibleLrcFilePath;
+                }
+            }
         }
 
         return '';


### PR DESCRIPTION
Lyrics folder search follows the the same capitalization as the prior `.lrc`, `.Lrc`, `.LRC` file search which was already used. First loop always check the same folder as the audio file before checking in a possible subfolder.

Note: Not sure how I would reflect this change in the `lrc-lyrics-getter.spec.ts` file as I'm not familiar with TypeScript.