### PR TITLE
Show album order options as a menu

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -294,6 +294,7 @@ import { CoverPlayerVolumeControlComponent } from './ui/components/mini-players/
 import { VolumeIconComponent } from './ui/components/volume-icon/volume-icon.component';
 import { EditTracksDialogComponent } from './ui/components/dialogs/edit-tracks-dialog/edit-tracks-dialog.component';
 import { InfoDialogComponent } from './ui/components/dialogs/info-dialog/info-dialog.component';
+import { IterableMenuComponent } from './ui/components/common/iterable-menu.component';
 
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -451,6 +452,7 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
         CoverPlayerVolumeControlComponent,
         VolumeIconComponent,
         EditTracksDialogComponent,
+        IterableMenuComponent,
     ],
     imports: [
         BrowserAnimationsModule,

--- a/src/app/services/artist/artist-type.spec.ts
+++ b/src/app/services/artist/artist-type.spec.ts
@@ -1,0 +1,24 @@
+import { ArtistType, artistTypeKey } from './artist-type';
+
+describe('ArtistType', () => {
+    describe('artistTypeKey', () => {
+        [
+            [ArtistType.trackArtists, 'track-artists'],
+            [ArtistType.albumArtists, 'album-artists'],
+            [ArtistType.allArtists, 'all-artists'],
+        ].forEach((pair) => {
+            const artistType = pair[0] as ArtistType;
+
+            it(`should return artist type key for ${artistType}`, () => {
+                // Arrange
+                const expectedArtistTypeKey = pair[1] as string;
+
+                // Act
+                const result = artistTypeKey(artistType);
+
+                // Assert
+                expect(result).toEqual(expectedArtistTypeKey);
+            });
+        });
+    });
+});

--- a/src/app/services/artist/artist-type.ts
+++ b/src/app/services/artist/artist-type.ts
@@ -3,3 +3,14 @@ export enum ArtistType {
     albumArtists = 2,
     allArtists = 3,
 }
+
+export function artistTypeKey(artistType: ArtistType): string {
+    switch (artistType) {
+        case ArtistType.trackArtists:
+            return 'track-artists';
+        case ArtistType.albumArtists:
+            return 'album-artists';
+        case ArtistType.allArtists:
+            return 'all-artists';
+    }
+}

--- a/src/app/ui/components/collection/album-browser/album-browser.component.html
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.html
@@ -6,34 +6,8 @@
             <div *ngIf="this.albums.length !== 1">{{ 'albums' | translate }}</div>
         </div>
 
-        <div class="pointer" (click)="toggleAlbumOrder()">
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byAlbumTitleAscending">
-                {{ 'by-album-title-ascending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byAlbumTitleDescending">
-                {{ 'by-album-title-descending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byDateAdded">
-                {{ 'by-date-added' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byDateCreated">
-                {{ 'by-date-created' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byAlbumArtist">
-                {{ 'by-album-artist' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byYearAscending">
-                {{ 'by-year-ascending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byYearDescending">
-                {{ 'by-year-descending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.byLastPlayed">
-                {{ 'by-last-played' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedAlbumOrder === albumOrderEnum.random">
-                {{ 'random' | translate }}
-            </div>
+        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
+            {{ albumOrderKey(this.selectedAlbumOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
         </div>
     </div>
     <cdk-virtual-scroll-viewport class="flex-grow mt-3" itemSize="170">
@@ -97,4 +71,13 @@
             </mat-menu>
         </ng-container>
     </div>
+</mat-menu>
+
+<mat-menu #orderMenu="matMenu">
+    <ng-container *ngFor="let order of albumOrders; let last = last">
+        <button mat-menu-item (click)="applyAlbumOrder(order)">
+            {{ albumOrderKey(order) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/album-browser/album-browser.component.html
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.html
@@ -5,10 +5,13 @@
             <div *ngIf="this.albums.length === 1">{{ 'album' | translate }}</div>
             <div *ngIf="this.albums.length !== 1">{{ 'albums' | translate }}</div>
         </div>
-
-        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
-            {{ albumOrderKey(this.selectedAlbumOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-        </div>
+        <app-iterable-menu
+            [tooltipKey]="'choose-order'"
+            [currentItem]="selectedAlbumOrder"
+            [items]="albumOrders"
+            [itemKeyFn]="albumOrderKey"
+            [applyItemFn]="applyAlbumOrder">
+        </app-iterable-menu>
     </div>
     <cdk-virtual-scroll-viewport class="flex-grow mt-3" itemSize="170">
         <div *cdkVirtualFor="let albumRow of this.albumRows">
@@ -71,13 +74,4 @@
             </mat-menu>
         </ng-container>
     </div>
-</mat-menu>
-
-<mat-menu #orderMenu="matMenu">
-    <ng-container *ngFor="let order of albumOrders; let last = last">
-        <button mat-menu-item (click)="applyAlbumOrder(order)">
-            {{ albumOrderKey(order) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/album-browser/album-browser.component.scss
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.scss
@@ -1,0 +1,5 @@
+.order-button {
+  width: fit-content !important;
+  padding: 5px;
+  cursor: pointer;
+}

--- a/src/app/ui/components/collection/album-browser/album-browser.component.scss
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.scss
@@ -1,5 +1,0 @@
-.order-button {
-  width: fit-content !important;
-  padding: 5px;
-  cursor: pointer;
-}

--- a/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
@@ -1,7 +1,7 @@
 import { Observable, Subject } from 'rxjs';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { AddToPlaylistMenu } from '../../add-to-playlist-menu';
-import { AlbumOrder } from '../album-order';
+import { AlbumOrder, albumOrderKey } from '../album-order';
 import { BaseAlbumsPersister } from '../base-albums-persister';
 import { AlbumBrowserComponent } from './album-browser.component';
 import { AlbumRowsGetter } from './album-rows-getter';
@@ -75,16 +75,6 @@ describe('AlbumBrowserComponent', () => {
 
             // Assert
             expect(component).toBeDefined();
-        });
-
-        it('should define albumOrderEnum', () => {
-            // Arrange
-
-            // Act
-            const component: AlbumBrowserComponent = createComponent();
-
-            // Assert
-            expect(component.albumOrderEnum).toBeDefined();
         });
 
         it('should define albumRows as empty', () => {
@@ -166,6 +156,36 @@ describe('AlbumBrowserComponent', () => {
 
             // Assert
             expect(component.addToPlaylistMenu).toBeDefined();
+        });
+
+        it('should define albumOrderKey', () => {
+            // Arrange
+
+            // Act
+            const component: AlbumBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.albumOrderKey).toEqual(albumOrderKey);
+        });
+
+        it('should define albumOrders', () => {
+            // Arrange
+
+            // Act
+            const component: AlbumBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.albumOrders).toEqual([
+                AlbumOrder.byAlbumTitleAscending,
+                AlbumOrder.byAlbumTitleDescending,
+                AlbumOrder.byDateAdded,
+                AlbumOrder.byDateCreated,
+                AlbumOrder.byAlbumArtist,
+                AlbumOrder.byYearAscending,
+                AlbumOrder.byYearDescending,
+                AlbumOrder.byLastPlayed,
+                AlbumOrder.random,
+            ]);
         });
     });
 

--- a/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.spec.ts
@@ -9,7 +9,6 @@ import { ApplicationServiceBase } from '../../../../services/application/applica
 import { NativeElementProxy } from '../../../../common/native-element-proxy';
 import { TranslatorServiceBase } from '../../../../services/translator/translator.service.base';
 import { MouseSelectionWatcher } from '../../mouse-selection-watcher';
-import { FileAccess } from '../../../../common/io/file-access';
 import { Logger } from '../../../../common/logger';
 import { ContextMenuOpener } from '../../context-menu-opener';
 import { AlbumData } from '../../../../data/entities/album-data';
@@ -469,124 +468,7 @@ describe('AlbumBrowserComponent', () => {
         });
     });
 
-    describe('toggleAlbumOrder', () => {
-        it('should change AlbumOrder from byAlbumTitleAscending to byAlbumTitleDescending', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byAlbumTitleAscending;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byAlbumTitleDescending);
-        });
-
-        it('should change AlbumOrder from byAlbumTitleDescending to byDateAdded', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byAlbumTitleDescending;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byDateAdded);
-        });
-
-        it('should change AlbumOrder from byDateAdded to byDateCreated', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byDateAdded;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byDateCreated);
-        });
-
-        it('should change AlbumOrder from byDateCreated to byAlbumArtist', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byDateCreated;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byAlbumArtist);
-        });
-
-        it('should change AlbumOrder from byAlbumArtist to byYearAscending', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byYearAscending);
-        });
-
-        it('should change AlbumOrder from byYearAscending to byYearDescending', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byYearAscending;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byYearDescending);
-        });
-
-        it('should change AlbumOrder from byYearDescending to byLastPlayed', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byYearDescending;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byLastPlayed);
-        });
-
-        it('should change AlbumOrder from byLastPlayed to random', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.albumsPersister = albumsPersisterMock.object;
-            component.selectedAlbumOrder = AlbumOrder.byLastPlayed;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.random);
-        });
-
-        it('should change AlbumOrder from random to byAlbumTitleAscending', () => {
-            // Arrange
-            const component: AlbumBrowserComponent = createComponent();
-            component.selectedAlbumOrder = AlbumOrder.random;
-            component.albumsPersister = albumsPersisterMock.object;
-
-            // Act
-            component.toggleAlbumOrder();
-
-            // Assert
-            expect(component.selectedAlbumOrder).toEqual(AlbumOrder.byAlbumTitleAscending);
-        });
-
+    describe('applyAlbumOrder', () => {
         it('should fill the album rows', () => {
             // Arrange
             const albumData1: AlbumData = new AlbumData();
@@ -597,14 +479,14 @@ describe('AlbumBrowserComponent', () => {
             nativeElementProxyMock.setup((x) => x.getElementWidth(It.isAny())).returns(() => 500);
             const component: AlbumBrowserComponent = createComponent();
             albumsPersisterMock.setup((x) => x.getSelectedAlbumOrder()).returns(() => AlbumOrder.byAlbumArtist);
-            component.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
+            component.selectedAlbumOrder = AlbumOrder.random;
             component.albumsPersister = albumsPersisterMock.object;
 
             component.albums = albums;
             albumRowsGetterMock.reset();
 
             // Act
-            component.toggleAlbumOrder();
+            component.applyAlbumOrder(AlbumOrder.byYearAscending);
 
             // Assert
             albumRowsGetterMock.verify((x) => x.getAlbumRows(It.isAny(), albums, AlbumOrder.byYearAscending), Times.exactly(1));
@@ -623,7 +505,7 @@ describe('AlbumBrowserComponent', () => {
             const component: AlbumBrowserComponent = createComponent();
             albumsPersisterMock.setup((x) => x.getSelectedAlbumOrder()).returns(() => AlbumOrder.byAlbumArtist);
             albumsPersisterMock.setup((x) => x.getSelectedAlbums(albums)).returns(() => [album2]);
-            component.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
+            component.selectedAlbumOrder = AlbumOrder.random;
             component.albumsPersister = albumsPersisterMock.object;
 
             component.albums = albums;
@@ -631,7 +513,7 @@ describe('AlbumBrowserComponent', () => {
             albums[1].isSelected = false;
 
             // Act
-            component.toggleAlbumOrder();
+            component.applyAlbumOrder(AlbumOrder.byAlbumArtist);
 
             // Assert
             expect(albums[0].isSelected).toBeFalsy();
@@ -648,17 +530,17 @@ describe('AlbumBrowserComponent', () => {
             nativeElementProxyMock.setup((x) => x.getElementWidth(It.isAny())).returns(() => 500);
             const component: AlbumBrowserComponent = createComponent();
             albumsPersisterMock.setup((x) => x.getSelectedAlbumOrder()).returns(() => AlbumOrder.byAlbumArtist);
-            component.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
+            component.selectedAlbumOrder = AlbumOrder.random;
             component.albumsPersister = albumsPersisterMock.object;
 
             component.albums = albums;
             albumRowsGetterMock.reset();
 
             // Act
-            component.toggleAlbumOrder();
+            component.applyAlbumOrder(AlbumOrder.byAlbumArtist);
 
             // Assert
-            albumsPersisterMock.verify((x) => x.setSelectedAlbumOrder(AlbumOrder.byYearAscending), Times.exactly(1));
+            albumsPersisterMock.verify((x) => x.setSelectedAlbumOrder(AlbumOrder.byAlbumArtist), Times.exactly(1));
         });
     });
 

--- a/src/app/ui/components/collection/album-browser/album-browser.component.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.ts
@@ -25,6 +25,9 @@ import { PlaybackService } from '../../../../services/playback/playback.service'
     providers: [MouseSelectionWatcher],
 })
 export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestroy {
+    public readonly albumOrders: AlbumOrder[] = Object.values(AlbumOrder).filter((x): x is AlbumOrder => typeof x === 'number');
+    public readonly albumOrderKey = albumOrderKey;
+
     private _albums: AlbumModel[] = [];
     private _albumsPersister: BaseAlbumsPersister;
     private availableWidthInPixels: number = 0;
@@ -57,7 +60,6 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
     @ViewChild('albumContextMenuAnchor', { read: MatMenuTrigger, static: false })
     public albumContextMenu: MatMenuTrigger;
 
-    public albumOrderEnum: typeof AlbumOrder = AlbumOrder;
     public albumRows: AlbumRow[] = [];
 
     public selectedAlbumOrder: AlbumOrder;
@@ -173,7 +175,4 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
     public async onAddToQueueAsync(album: AlbumModel): Promise<void> {
         await this.playbackService.addAlbumToQueueAsync(album);
     }
-
-    protected readonly albumOrders: AlbumOrder[] = Object.values(AlbumOrder).filter((x): x is AlbumOrder => typeof x === 'number');
-    protected readonly albumOrderKey = albumOrderKey;
 }

--- a/src/app/ui/components/collection/album-browser/album-browser.component.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Constants } from '../../../../common/application/constants';
@@ -6,7 +6,7 @@ import { Logger } from '../../../../common/logger';
 import { NativeElementProxy } from '../../../../common/native-element-proxy';
 import { AlbumModel } from '../../../../services/album/album-model';
 import { AddToPlaylistMenu } from '../../add-to-playlist-menu';
-import { AlbumOrder } from '../album-order';
+import { AlbumOrder, albumOrderKey } from '../album-order';
 import { BaseAlbumsPersister } from '../base-albums-persister';
 import { AlbumRow } from './album-row';
 import { AlbumRowsGetter } from './album-rows-getter';
@@ -112,41 +112,8 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
         this.albumsPersister.setSelectedAlbums(this.mouseSelectionWatcher.selectedItems as AlbumModel[]);
     }
 
-    public toggleAlbumOrder(): void {
-        switch (this.selectedAlbumOrder) {
-            case AlbumOrder.byAlbumTitleAscending:
-                this.selectedAlbumOrder = AlbumOrder.byAlbumTitleDescending;
-                break;
-            case AlbumOrder.byAlbumTitleDescending:
-                this.selectedAlbumOrder = AlbumOrder.byDateAdded;
-                break;
-            case AlbumOrder.byDateAdded:
-                this.selectedAlbumOrder = AlbumOrder.byDateCreated;
-                break;
-            case AlbumOrder.byDateCreated:
-                this.selectedAlbumOrder = AlbumOrder.byAlbumArtist;
-                break;
-            case AlbumOrder.byAlbumArtist:
-                this.selectedAlbumOrder = AlbumOrder.byYearAscending;
-                break;
-            case AlbumOrder.byYearAscending:
-                this.selectedAlbumOrder = AlbumOrder.byYearDescending;
-                break;
-            case AlbumOrder.byYearDescending:
-                this.selectedAlbumOrder = AlbumOrder.byLastPlayed;
-                break;
-            case AlbumOrder.byLastPlayed:
-                this.selectedAlbumOrder = AlbumOrder.random;
-                break;
-            case AlbumOrder.random:
-                this.selectedAlbumOrder = AlbumOrder.byAlbumTitleAscending;
-                break;
-            default: {
-                this.selectedAlbumOrder = AlbumOrder.byAlbumTitleAscending;
-                break;
-            }
-        }
-
+    public applyAlbumOrder(albumOrder: AlbumOrder): void {
+        this.selectedAlbumOrder = albumOrder;
         this.albumsPersister.setSelectedAlbumOrder(this.selectedAlbumOrder);
         this.orderAlbums();
     }
@@ -206,4 +173,7 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
     public async onAddToQueueAsync(album: AlbumModel): Promise<void> {
         await this.playbackService.addAlbumToQueueAsync(album);
     }
+
+    protected readonly albumOrders: AlbumOrder[] = Object.values(AlbumOrder).filter((x): x is AlbumOrder => typeof x === 'number');
+    protected readonly albumOrderKey = albumOrderKey;
 }

--- a/src/app/ui/components/collection/album-browser/album-browser.component.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.ts
@@ -112,11 +112,11 @@ export class AlbumBrowserComponent implements AfterViewInit, OnChanges, OnDestro
         this.albumsPersister.setSelectedAlbums(this.mouseSelectionWatcher.selectedItems as AlbumModel[]);
     }
 
-    public applyAlbumOrder(albumOrder: AlbumOrder): void {
+    public applyAlbumOrder = (albumOrder: AlbumOrder): void => {
         this.selectedAlbumOrder = albumOrder;
         this.albumsPersister.setSelectedAlbumOrder(this.selectedAlbumOrder);
         this.orderAlbums();
-    }
+    };
 
     private applySelectedAlbums(): void {
         const selectedAlbums: AlbumModel[] = this.albumsPersister.getSelectedAlbums(this.albums);

--- a/src/app/ui/components/collection/album-order.spec.ts
+++ b/src/app/ui/components/collection/album-order.spec.ts
@@ -1,0 +1,30 @@
+import { AlbumOrder, albumOrderKey } from './album-order';
+
+describe('AlbumOrder', () => {
+    describe('albumOrderKey', () => {
+        [
+            [AlbumOrder.byAlbumTitleAscending, 'by-album-title-ascending'],
+            [AlbumOrder.byAlbumTitleDescending, 'by-album-title-descending'],
+            [AlbumOrder.byDateAdded, 'by-date-added'],
+            [AlbumOrder.byDateCreated, 'by-date-created'],
+            [AlbumOrder.byAlbumArtist, 'by-album-artist'],
+            [AlbumOrder.byYearAscending, 'by-year-ascending'],
+            [AlbumOrder.byYearDescending, 'by-year-descending'],
+            [AlbumOrder.byLastPlayed, 'by-last-played'],
+            [AlbumOrder.random, 'random'],
+        ].forEach((pair) => {
+            const albumOrder = pair[0] as AlbumOrder;
+
+            it(`should return album order key for ${albumOrder}`, () => {
+                // Arrange
+                const expectedAlbumOrderKey = pair[1] as string;
+
+                // Act
+                const result = albumOrderKey(albumOrder);
+
+                // Assert
+                expect(result).toEqual(expectedAlbumOrderKey);
+            });
+        });
+    });
+});

--- a/src/app/ui/components/collection/album-order.ts
+++ b/src/app/ui/components/collection/album-order.ts
@@ -9,3 +9,26 @@ export enum AlbumOrder {
     byLastPlayed = 8,
     random = 9,
 }
+
+export function albumOrderKey(albumOrder: AlbumOrder): string {
+    switch (albumOrder) {
+        case AlbumOrder.byAlbumTitleAscending:
+            return 'by-album-title-ascending';
+        case AlbumOrder.byAlbumTitleDescending:
+            return 'by-album-title-descending';
+        case AlbumOrder.byDateAdded:
+            return 'by-date-added';
+        case AlbumOrder.byDateCreated:
+            return 'by-date-created';
+        case AlbumOrder.byAlbumArtist:
+            return 'by-album-artist';
+        case AlbumOrder.byYearAscending:
+            return 'by-year-ascending';
+        case AlbumOrder.byYearDescending:
+            return 'by-year-descending';
+        case AlbumOrder.byLastPlayed:
+            return 'by-last-played';
+        case AlbumOrder.random:
+            return 'random';
+    }
+}

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.html
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.html
@@ -2,13 +2,21 @@
     <div class="h-24px align-items-center justify-content-between d-flex flex-row m-1">
         <div class="d-flex flex-row align-items-center">
             <div class="mr-2 accent-color">{{ this.artists.length }}</div>
-            <div class="window-button order-button" [matMenuTriggerFor]="artistTypeMenu" matTooltip="{{ 'choose-type' | translate }}">
-                {{ artistTypeKey(this.selectedArtistType) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-            </div>
+            <app-iterable-menu
+                [tooltipKey]="'choose-type'"
+                [currentItem]="selectedArtistType"
+                [items]="artistTypes"
+                [itemKeyFn]="artistTypeKey"
+                [applyItemFn]="applyArtistType">
+            </app-iterable-menu>
         </div>
-        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
-            {{ artistOrderKey(this.selectedArtistOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-        </div>
+        <app-iterable-menu
+            [tooltipKey]="'choose-order'"
+            [currentItem]="selectedArtistOrder"
+            [items]="artistOrders"
+            [itemKeyFn]="artistOrderKey"
+            [applyItemFn]="applyArtistOrder">
+        </app-iterable-menu>
     </div>
     <app-semantic-zoom *ngIf="this.shouldZoomOut" class="mt-3" [SemanticZoomables]="this.orderedArtists"></app-semantic-zoom>
     <cdk-virtual-scroll-viewport *ngIf="!this.shouldZoomOut" class="flex-grow mt-3" itemSize="30">
@@ -65,22 +73,4 @@
             </mat-menu>
         </ng-container>
     </div>
-</mat-menu>
-
-<mat-menu #artistTypeMenu="matMenu">
-    <ng-container *ngFor="let artistType of artistTypes; let last = last">
-        <button mat-menu-item (click)="applyArtistType(artistType)">
-            {{ artistTypeKey(artistType) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
-</mat-menu>
-
-<mat-menu #orderMenu="matMenu">
-    <ng-container *ngFor="let order of artistOrders; let last = last">
-        <button mat-menu-item (click)="applyArtistOrder(order)">
-            {{ artistOrderKey(order) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.html
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.html
@@ -2,23 +2,12 @@
     <div class="h-24px align-items-center justify-content-between d-flex flex-row m-1">
         <div class="d-flex flex-row align-items-center">
             <div class="mr-2 accent-color">{{ this.artists.length }}</div>
-            <div class="pointer" *ngIf="this.selectedArtistType === artistTypeEnum.trackArtists" (click)="this.toggleArtistType()">
-                {{ 'track-artists' | translate }}
-            </div>
-            <div class="pointer" *ngIf="this.selectedArtistType === artistTypeEnum.albumArtists" (click)="this.toggleArtistType()">
-                {{ 'album-artists' | translate }}
-            </div>
-            <div class="pointer" *ngIf="this.selectedArtistType === artistTypeEnum.allArtists" (click)="this.toggleArtistType()">
-                {{ 'all-artists' | translate }}
+            <div class="window-button order-button" [matMenuTriggerFor]="artistTypeMenu" matTooltip="{{ 'choose-type' | translate }}">
+                {{ artistTypeKey(this.selectedArtistType) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
             </div>
         </div>
-        <div class="pointer" (click)="toggleArtistOrder()">
-            <div class="secondary-text" *ngIf="this.selectedArtistOrder === artistOrderEnum.byArtistAscending">
-                {{ 'by-artist-ascending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedArtistOrder === artistOrderEnum.byArtistDescending">
-                {{ 'by-artist-descending' | translate }}
-            </div>
+        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
+            {{ artistOrderKey(this.selectedArtistOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
         </div>
     </div>
     <app-semantic-zoom *ngIf="this.shouldZoomOut" class="mt-3" [SemanticZoomables]="this.orderedArtists"></app-semantic-zoom>
@@ -76,4 +65,22 @@
             </mat-menu>
         </ng-container>
     </div>
+</mat-menu>
+
+<mat-menu #artistTypeMenu="matMenu">
+    <ng-container *ngFor="let artistType of artistTypes; let last = last">
+        <button mat-menu-item (click)="applyArtistType(artistType)">
+            {{ artistTypeKey(artistType) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
+</mat-menu>
+
+<mat-menu #orderMenu="matMenu">
+    <ng-container *ngFor="let order of artistOrders; let last = last">
+        <button mat-menu-item (click)="applyArtistOrder(order)">
+            {{ artistOrderKey(order) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.spec.ts
@@ -3,13 +3,13 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { AddToPlaylistMenu } from '../../../add-to-playlist-menu';
 import { ArtistsPersister } from '../artists-persister';
 import { ArtistBrowserComponent } from './artist-browser.component';
-import { ArtistOrder } from './artist-order';
+import { ArtistOrder, artistOrderKey } from './artist-order';
 import { ArtistModel } from '../../../../../services/artist/artist-model';
 import { Logger } from '../../../../../common/logger';
 import { ContextMenuOpener } from '../../../context-menu-opener';
 import { MouseSelectionWatcher } from '../../../mouse-selection-watcher';
 import { SemanticZoomHeaderAdder } from '../../../../../common/semantic-zoom-header-adder';
-import { ArtistType } from '../../../../../services/artist/artist-type';
+import { ArtistType, artistTypeKey } from '../../../../../services/artist/artist-type';
 import { Constants } from '../../../../../common/application/constants';
 import { SemanticZoomServiceBase } from '../../../../../services/semantic-zoom/semantic-zoom.service.base';
 import { ApplicationServiceBase } from '../../../../../services/application/application.service.base';
@@ -157,16 +157,6 @@ describe('ArtistBrowserComponent', () => {
             expect(component.orderedArtists.length).toEqual(0);
         });
 
-        it('should define artistOrderEnum', () => {
-            // Arrange
-
-            // Act
-            const component: ArtistBrowserComponent = createComponent();
-
-            // Assert
-            expect(component.artistOrderEnum).toBeDefined();
-        });
-
         it('should declare selectedArtistOrder', () => {
             // Arrange
 
@@ -175,16 +165,6 @@ describe('ArtistBrowserComponent', () => {
 
             // Assert
             expect(component.selectedArtistOrder).toBeUndefined();
-        });
-
-        it('should define artistTypeEnum', () => {
-            // Arrange
-
-            // Act
-            const component: ArtistBrowserComponent = createComponent();
-
-            // Assert
-            expect(component.artistTypeEnum).toBeDefined();
         });
 
         it('should declare selectedArtistType', () => {
@@ -265,6 +245,46 @@ describe('ArtistBrowserComponent', () => {
 
             // Assert
             expect(component.shouldZoomOut).toBeFalsy();
+        });
+
+        it('should define artistTypes', () => {
+            // Arrange
+
+            // Act
+            const component: ArtistBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.artistTypes).toEqual([ArtistType.trackArtists, ArtistType.albumArtists, ArtistType.allArtists]);
+        });
+
+        it('should define artistTypeKey', () => {
+            // Arrange
+
+            // Act
+            const component: ArtistBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.artistTypeKey).toEqual(artistTypeKey);
+        });
+
+        it('should define artistOrders', () => {
+            // Arrange
+
+            // Act
+            const component: ArtistBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.artistOrders).toEqual([ArtistOrder.byArtistAscending, ArtistOrder.byArtistDescending]);
+        });
+
+        it('should define artistOrderKey', () => {
+            // Arrange
+
+            // Act
+            const component: ArtistBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.artistOrderKey).toEqual(artistOrderKey);
         });
     });
 

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.spec.ts
@@ -629,83 +629,47 @@ describe('ArtistBrowserComponent', () => {
         });
     });
 
-    describe('toggleArtistOrder', () => {
-        it('should toggle selectedArtistOrder from byArtistAscending to byArtistDescending', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistOrder = ArtistOrder.byArtistAscending;
-
-            // Act
-            component.toggleArtistOrder();
-
-            // Assert
-            expect(component.selectedArtistOrder).toEqual(ArtistOrder.byArtistDescending);
-        });
-
-        it('should toggle selectedArtistOrder from byArtistDescending to byArtistAscending', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistOrder = ArtistOrder.byArtistDescending;
-
-            // Act
-            component.toggleArtistOrder();
-
-            // Assert
-            expect(component.selectedArtistOrder).toEqual(ArtistOrder.byArtistAscending);
-        });
-
-        it('should persist the selected artist order', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistOrder = ArtistOrder.byArtistDescending;
-
-            // Act
-            component.toggleArtistOrder();
-
-            // Assert
-            artistsPersisterMock.verify((x) => x.setSelectedArtistOrder(component.selectedArtistOrder), Times.once());
-        });
-
-        it('should order the artists by artist descending if the selected artist order is byArtistAscending', () => {
-            // Arrange
-            artistsPersisterMock.reset();
-            artistsPersisterMock.setup((x) => x.getSelectedArtistOrder()).returns(() => ArtistOrder.byArtistAscending);
-
-            const component: ArtistBrowserComponent = createComponent();
-
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-
-            // Act
-            component.toggleArtistOrder();
-
-            // Assert
-            expect(component.orderedArtists[1]).toEqual(artist2);
-            expect(component.orderedArtists[3]).toEqual(artist1);
-        });
-
-        it('should order the artists by artist ascending if the selected artist order is byArtistDescending', () => {
+    describe('applyArtistOrder', () => {
+        it('should apply artist order by artist ascending', () => {
             // Arrange
             artistsPersisterMock.reset();
             artistsPersisterMock.setup((x) => x.getSelectedArtistOrder()).returns(() => ArtistOrder.byArtistDescending);
 
             const component: ArtistBrowserComponent = createComponent();
-
             component.artists = [artist1, artist2];
             component.artistsPersister = artistsPersisterMock.object;
 
+            const artistOrder = ArtistOrder.byArtistAscending;
+
             // Act
-            component.toggleArtistOrder();
+            component.applyArtistOrder(artistOrder);
 
             // Assert
+            expect(component.selectedArtistOrder).toEqual(artistOrder);
+            artistsPersisterMock.verify((x) => x.setSelectedArtistOrder(artistOrder), Times.once());
             expect(component.orderedArtists[1]).toEqual(artist1);
             expect(component.orderedArtists[3]).toEqual(artist2);
+        });
+
+        it('should apply artist order by artist descending', () => {
+            // Arrange
+            artistsPersisterMock.reset();
+            artistsPersisterMock.setup((x) => x.getSelectedArtistOrder()).returns(() => ArtistOrder.byArtistAscending);
+
+            const component: ArtistBrowserComponent = createComponent();
+            component.artists = [artist1, artist2];
+            component.artistsPersister = artistsPersisterMock.object;
+
+            const artistOrder = ArtistOrder.byArtistDescending;
+
+            // Act
+            component.applyArtistOrder(artistOrder);
+
+            // Assert
+            expect(component.selectedArtistOrder).toEqual(artistOrder);
+            artistsPersisterMock.verify((x) => x.setSelectedArtistOrder(artistOrder), Times.once());
+            expect(component.orderedArtists[1]).toEqual(artist2);
+            expect(component.orderedArtists[3]).toEqual(artist1);
         });
 
         it('should show the headers for the ordered artists', () => {
@@ -723,68 +687,29 @@ describe('ArtistBrowserComponent', () => {
             semanticZoomHeaderAdderMock.setup((x) => x.addZoomHeaders([artist1, artist2])).returns(() => [artist1, artist2]);
 
             // Act
-            component.toggleArtistOrder();
+            component.applyArtistOrder(ArtistOrder.byArtistAscending);
 
             // Assert
             semanticZoomHeaderAdderMock.verify((x) => x.addZoomHeaders(component.orderedArtists), Times.once());
         });
     });
 
-    describe('toggleArtistType', () => {
-        it('should toggle selectedArtistType from trackArtists to albumArtists', () => {
+    describe('applyArtistType', () => {
+        it('should apply artist type', () => {
             // Arrange
             const component: ArtistBrowserComponent = createComponent();
             component.artists = [artist1, artist2];
             component.artistsPersister = artistsPersisterMock.object;
             component.selectedArtistType = ArtistType.trackArtists;
 
-            // Act
-            component.toggleArtistType();
-
-            // Assert
-            expect(component.selectedArtistType).toEqual(ArtistType.albumArtists);
-        });
-
-        it('should toggle selectedArtistType from albumArtists to allArtists', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistType = ArtistType.albumArtists;
+            const artistType = ArtistType.allArtists;
 
             // Act
-            component.toggleArtistType();
+            component.applyArtistType(artistType);
 
             // Assert
-            expect(component.selectedArtistType).toEqual(ArtistType.allArtists);
-        });
-
-        it('should toggle selectedArtistType from allArtists to trackArtists', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistType = ArtistType.allArtists;
-
-            // Act
-            component.toggleArtistType();
-
-            // Assert
-            expect(component.selectedArtistType).toEqual(ArtistType.trackArtists);
-        });
-
-        it('should persist the selected artist type', () => {
-            // Arrange
-            const component: ArtistBrowserComponent = createComponent();
-            component.artists = [artist1, artist2];
-            component.artistsPersister = artistsPersisterMock.object;
-            component.selectedArtistType = ArtistType.allArtists;
-
-            // Act
-            component.toggleArtistType();
-
-            // Assert
-            artistsPersisterMock.verify((x) => x.setSelectedArtistType(component.selectedArtistType), Times.once());
+            expect(component.selectedArtistType).toEqual(artistType);
+            artistsPersisterMock.verify((x) => x.setSelectedArtistType(artistType), Times.once());
         });
     });
 

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
@@ -30,6 +30,12 @@ import { Timer } from '../../../../../common/scheduling/timer';
 export class ArtistBrowserComponent implements OnInit, OnDestroy {
     @ViewChild(CdkVirtualScrollViewport) public viewPort: CdkVirtualScrollViewport;
 
+    public readonly artistTypes: ArtistType[] = Object.values(ArtistType).filter((x): x is ArtistType => typeof x === 'number');
+    public readonly artistTypeKey = artistTypeKey;
+
+    public readonly artistOrders: ArtistOrder[] = Object.values(ArtistOrder).filter((x): x is ArtistOrder => typeof x === 'number');
+    public readonly artistOrderKey = artistOrderKey;
+
     private _artists: ArtistModel[] = [];
     private _artistsPersister: ArtistsPersister;
     private subscription: Subscription = new Subscription();
@@ -54,10 +60,8 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
 
     public orderedArtists: ArtistModel[] = [];
 
-    public artistOrderEnum: typeof ArtistOrder = ArtistOrder;
     public selectedArtistOrder: ArtistOrder;
 
-    public artistTypeEnum: typeof ArtistType = ArtistType;
     public selectedArtistType: ArtistType;
 
     public get artistsPersister(): ArtistsPersister {
@@ -193,10 +197,4 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
             this.viewPort.scrollToIndex(selectedIndex, 'smooth');
         }
     }
-
-    protected readonly artistTypes: ArtistType[] = Object.values(ArtistType).filter((x): x is ArtistType => typeof x === 'number');
-    protected readonly artistTypeKey = artistTypeKey;
-
-    protected readonly artistOrders: ArtistOrder[] = Object.values(ArtistOrder).filter((x): x is ArtistOrder => typeof x === 'number');
-    protected readonly artistOrderKey = artistOrderKey;
 }

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
@@ -118,16 +118,16 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
         }
     }
 
-    public applyArtistType(artistType: ArtistType): void {
+    public applyArtistType = (artistType: ArtistType): void => {
         this.selectedArtistType = artistType;
         this.artistsPersister.setSelectedArtistType(this.selectedArtistType);
-    }
+    };
 
-    public applyArtistOrder(artistOrder: ArtistOrder): void {
+    public applyArtistOrder = (artistOrder: ArtistOrder): void => {
         this.selectedArtistOrder = artistOrder;
         this.artistsPersister.setSelectedArtistOrder(this.selectedArtistOrder);
         this.orderArtists();
-    }
+    };
 
     public onArtistContextMenu(event: MouseEvent, artist: ArtistModel): void {
         this.contextMenuOpener.open(this.artistContextMenu, event, artist);

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-browser.component.ts
@@ -7,10 +7,10 @@ import { Logger } from '../../../../../common/logger';
 import { SemanticZoomHeaderAdder } from '../../../../../common/semantic-zoom-header-adder';
 import { PromiseUtils } from '../../../../../common/utils/promise-utils';
 import { ArtistModel } from '../../../../../services/artist/artist-model';
-import { ArtistType } from '../../../../../services/artist/artist-type';
+import { ArtistType, artistTypeKey } from '../../../../../services/artist/artist-type';
 import { AddToPlaylistMenu } from '../../../add-to-playlist-menu';
 import { ArtistsPersister } from '../artists-persister';
-import { ArtistOrder } from './artist-order';
+import { ArtistOrder, artistOrderKey } from './artist-order';
 import { PlaybackService } from '../../../../../services/playback/playback.service';
 import { SemanticZoomServiceBase } from '../../../../../services/semantic-zoom/semantic-zoom.service.base';
 import { ApplicationServiceBase } from '../../../../../services/application/application.service.base';
@@ -118,40 +118,13 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
         }
     }
 
-    public toggleArtistType(): void {
-        switch (this.selectedArtistType) {
-            case ArtistType.trackArtists:
-                this.selectedArtistType = ArtistType.albumArtists;
-                break;
-            case ArtistType.albumArtists:
-                this.selectedArtistType = ArtistType.allArtists;
-                break;
-            case ArtistType.allArtists:
-                this.selectedArtistType = ArtistType.trackArtists;
-                break;
-            default: {
-                this.selectedArtistType = ArtistType.trackArtists;
-                break;
-            }
-        }
-
+    public applyArtistType(artistType: ArtistType): void {
+        this.selectedArtistType = artistType;
         this.artistsPersister.setSelectedArtistType(this.selectedArtistType);
     }
 
-    public toggleArtistOrder(): void {
-        switch (this.selectedArtistOrder) {
-            case ArtistOrder.byArtistAscending:
-                this.selectedArtistOrder = ArtistOrder.byArtistDescending;
-                break;
-            case ArtistOrder.byArtistDescending:
-                this.selectedArtistOrder = ArtistOrder.byArtistAscending;
-                break;
-            default: {
-                this.selectedArtistOrder = ArtistOrder.byArtistAscending;
-                break;
-            }
-        }
-
+    public applyArtistOrder(artistOrder: ArtistOrder): void {
+        this.selectedArtistOrder = artistOrder;
         this.artistsPersister.setSelectedArtistOrder(this.selectedArtistOrder);
         this.orderArtists();
     }
@@ -205,10 +178,6 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
     private applySelectedArtists(): void {
         const selectedArtists: ArtistModel[] = this.artistsPersister.getSelectedArtists(this.artists);
 
-        if (selectedArtists == undefined) {
-            return;
-        }
-
         for (const selectedArtist of selectedArtists) {
             selectedArtist.isSelected = true;
         }
@@ -224,4 +193,10 @@ export class ArtistBrowserComponent implements OnInit, OnDestroy {
             this.viewPort.scrollToIndex(selectedIndex, 'smooth');
         }
     }
+
+    protected readonly artistTypes: ArtistType[] = Object.values(ArtistType).filter((x): x is ArtistType => typeof x === 'number');
+    protected readonly artistTypeKey = artistTypeKey;
+
+    protected readonly artistOrders: ArtistOrder[] = Object.values(ArtistOrder).filter((x): x is ArtistOrder => typeof x === 'number');
+    protected readonly artistOrderKey = artistOrderKey;
 }

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-order.spec.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-order.spec.ts
@@ -1,0 +1,23 @@
+import { ArtistOrder, artistOrderKey } from './artist-order';
+
+describe('ArtistOrder', () => {
+    describe('artistOrderKey', () => {
+        [
+            [ArtistOrder.byArtistAscending, 'by-artist-ascending'],
+            [ArtistOrder.byArtistDescending, 'by-artist-descending'],
+        ].forEach((pair) => {
+            const artistOrder = pair[0] as ArtistOrder;
+
+            it(`should return artist order key for ${artistOrder}`, () => {
+                // Arrange
+                const expectedArtistOrderKey = pair[1] as string;
+
+                // Act
+                const result = artistOrderKey(artistOrder);
+
+                // Assert
+                expect(result).toEqual(expectedArtistOrderKey);
+            });
+        });
+    });
+});

--- a/src/app/ui/components/collection/collection-artists/artist-browser/artist-order.ts
+++ b/src/app/ui/components/collection/collection-artists/artist-browser/artist-order.ts
@@ -2,3 +2,12 @@ export enum ArtistOrder {
     byArtistAscending = 1,
     byArtistDescending = 2,
 }
+
+export function artistOrderKey(artistOrder: ArtistOrder): string {
+    switch (artistOrder) {
+        case ArtistOrder.byArtistAscending:
+            return 'by-artist-ascending';
+        case ArtistOrder.byArtistDescending:
+            return 'by-artist-descending';
+    }
+}

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.html
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.html
@@ -5,9 +5,13 @@
             <div *ngIf="this.genres.length === 1">{{ 'genre' | translate }}</div>
             <div *ngIf="this.genres.length !== 1">{{ 'genres' | translate }}</div>
         </div>
-        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
-            {{ genreOrderKey(this.selectedGenreOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-        </div>
+        <app-iterable-menu
+            [tooltipKey]="'choose-order'"
+            [currentItem]="selectedGenreOrder"
+            [items]="genreOrders"
+            [itemKeyFn]="genreOrderKey"
+            [applyItemFn]="applyGenreOrder">
+        </app-iterable-menu>
     </div>
     <app-semantic-zoom *ngIf="this.shouldZoomOut" class="mt-3" [SemanticZoomables]="this.orderedGenres"></app-semantic-zoom>
     <cdk-virtual-scroll-viewport *ngIf="!this.shouldZoomOut" class="flex-grow mt-3" itemSize="30">
@@ -65,13 +69,4 @@
             </mat-menu>
         </ng-container>
     </div>
-</mat-menu>
-
-<mat-menu #orderMenu="matMenu">
-    <ng-container *ngFor="let order of genreOrders; let last = last">
-        <button mat-menu-item (click)="applyGenreOrder(order)">
-            {{ genreOrderKey(order) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.html
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.html
@@ -5,13 +5,8 @@
             <div *ngIf="this.genres.length === 1">{{ 'genre' | translate }}</div>
             <div *ngIf="this.genres.length !== 1">{{ 'genres' | translate }}</div>
         </div>
-        <div class="pointer" (click)="toggleGenreOrder()">
-            <div class="secondary-text" *ngIf="this.selectedGenreOrder === genreOrderEnum.byGenreAscending">
-                {{ 'by-genre-ascending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedGenreOrder === genreOrderEnum.byGenreDescending">
-                {{ 'by-genre-descending' | translate }}
-            </div>
+        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
+            {{ genreOrderKey(this.selectedGenreOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
         </div>
     </div>
     <app-semantic-zoom *ngIf="this.shouldZoomOut" class="mt-3" [SemanticZoomables]="this.orderedGenres"></app-semantic-zoom>
@@ -70,4 +65,13 @@
             </mat-menu>
         </ng-container>
     </div>
+</mat-menu>
+
+<mat-menu #orderMenu="matMenu">
+    <ng-container *ngFor="let order of genreOrders; let last = last">
+        <button mat-menu-item (click)="applyGenreOrder(order)">
+            {{ genreOrderKey(order) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.spec.ts
@@ -3,7 +3,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { AddToPlaylistMenu } from '../../../add-to-playlist-menu';
 import { GenresPersister } from '../genres-persister';
 import { GenreBrowserComponent } from './genre-browser.component';
-import { GenreOrder } from './genre-order';
+import { GenreOrder, genreOrderKey } from './genre-order';
 import { PlaybackService } from '../../../../../services/playback/playback.service';
 import { SemanticZoomServiceBase } from '../../../../../services/semantic-zoom/semantic-zoom.service.base';
 import { ApplicationServiceBase } from '../../../../../services/application/application.service.base';
@@ -157,16 +157,6 @@ describe('GenreBrowserComponent', () => {
             expect(component.orderedGenres.length).toEqual(0);
         });
 
-        it('should define genreOrderEnum', () => {
-            // Arrange
-
-            // Act
-            const component: GenreBrowserComponent = createComponent();
-
-            // Assert
-            expect(component.genreOrderEnum).toBeDefined();
-        });
-
         it('should declare selectedGenreOrder', () => {
             // Arrange
 
@@ -245,6 +235,26 @@ describe('GenreBrowserComponent', () => {
 
             // Assert
             expect(component.shouldZoomOut).toBeFalsy();
+        });
+
+        it('should define genreOrders', () => {
+            // Arrange
+
+            // Act
+            const component: GenreBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.genreOrders).toEqual([GenreOrder.byGenreAscending, GenreOrder.byGenreDescending]);
+        });
+
+        it('should define genreOrderKey', () => {
+            // Arrange
+
+            // Act
+            const component: GenreBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.genreOrderKey).toEqual(genreOrderKey);
         });
     });
 

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.spec.ts
@@ -609,83 +609,47 @@ describe('GenreBrowserComponent', () => {
         });
     });
 
-    describe('toggleGenreOrder', () => {
-        it('should toggle selectedGenreOrder from byGenreAscending to byGenreDescending', () => {
-            // Arrange
-            const component: GenreBrowserComponent = createComponent();
-            component.genres = [genre1, genre2];
-            component.genresPersister = genresPersisterMock.object;
-            component.selectedGenreOrder = GenreOrder.byGenreAscending;
-
-            // Act
-            component.toggleGenreOrder();
-
-            // Assert
-            expect(component.selectedGenreOrder).toEqual(GenreOrder.byGenreDescending);
-        });
-
-        it('should toggle selectedGenreOrder from byGenreDescending to byGenreAscending', () => {
-            // Arrange
-            const component: GenreBrowserComponent = createComponent();
-            component.genres = [genre1, genre2];
-            component.genresPersister = genresPersisterMock.object;
-            component.selectedGenreOrder = GenreOrder.byGenreDescending;
-
-            // Act
-            component.toggleGenreOrder();
-
-            // Assert
-            expect(component.selectedGenreOrder).toEqual(GenreOrder.byGenreAscending);
-        });
-
-        it('should persist the selected genre order', () => {
-            // Arrange
-            const component: GenreBrowserComponent = createComponent();
-            component.genres = [genre1, genre2];
-            component.genresPersister = genresPersisterMock.object;
-            component.selectedGenreOrder = GenreOrder.byGenreDescending;
-
-            // Act
-            component.toggleGenreOrder();
-
-            // Assert
-            genresPersisterMock.verify((x) => x.setSelectedGenreOrder(component.selectedGenreOrder), Times.once());
-        });
-
-        it('should order the genres by genre descending if the selected genre order is byGenreAscending', () => {
-            // Arrange
-            genresPersisterMock.reset();
-            genresPersisterMock.setup((x) => x.getSelectedGenreOrder()).returns(() => GenreOrder.byGenreAscending);
-
-            const component: GenreBrowserComponent = createComponent();
-
-            component.genres = [genre1, genre2];
-            component.genresPersister = genresPersisterMock.object;
-
-            // Act
-            component.toggleGenreOrder();
-
-            // Assert
-            expect(component.orderedGenres[1]).toEqual(genre2);
-            expect(component.orderedGenres[3]).toEqual(genre1);
-        });
-
-        it('should order the genres by genre ascending if the selected genre order is byGenreDescending', () => {
+    describe('applyGenreOrder', () => {
+        it('should apply genre order by genre ascending', () => {
             // Arrange
             genresPersisterMock.reset();
             genresPersisterMock.setup((x) => x.getSelectedGenreOrder()).returns(() => GenreOrder.byGenreDescending);
 
             const component: GenreBrowserComponent = createComponent();
-
             component.genres = [genre1, genre2];
             component.genresPersister = genresPersisterMock.object;
 
+            const genreOrder = GenreOrder.byGenreAscending;
+
             // Act
-            component.toggleGenreOrder();
+            component.applyGenreOrder(genreOrder);
 
             // Assert
+            expect(component.selectedGenreOrder).toEqual(genreOrder);
+            genresPersisterMock.verify((x) => x.setSelectedGenreOrder(genreOrder), Times.once());
             expect(component.orderedGenres[1]).toEqual(genre1);
             expect(component.orderedGenres[3]).toEqual(genre2);
+        });
+
+        it('should apply genre order by genre descending', () => {
+            // Arrange
+            genresPersisterMock.reset();
+            genresPersisterMock.setup((x) => x.getSelectedGenreOrder()).returns(() => GenreOrder.byGenreAscending);
+
+            const component: GenreBrowserComponent = createComponent();
+            component.genres = [genre1, genre2];
+            component.genresPersister = genresPersisterMock.object;
+
+            const genreOrder = GenreOrder.byGenreDescending;
+
+            // Act
+            component.applyGenreOrder(genreOrder);
+
+            // Assert
+            expect(component.selectedGenreOrder).toEqual(genreOrder);
+            genresPersisterMock.verify((x) => x.setSelectedGenreOrder(genreOrder), Times.once());
+            expect(component.orderedGenres[1]).toEqual(genre2);
+            expect(component.orderedGenres[3]).toEqual(genre1);
         });
 
         it('should show the headers for the ordered genres', () => {
@@ -703,7 +667,7 @@ describe('GenreBrowserComponent', () => {
             semanticZoomHeaderAdderMock.setup((x) => x.addZoomHeaders([genre1, genre2])).returns(() => [genre1, genre2]);
 
             // Act
-            component.toggleGenreOrder();
+            component.applyGenreOrder(GenreOrder.byGenreAscending);
 
             // Assert
             semanticZoomHeaderAdderMock.verify((x) => x.addZoomHeaders(component.orderedGenres), Times.once());

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
@@ -9,7 +9,7 @@ import { PromiseUtils } from '../../../../../common/utils/promise-utils';
 import { GenreModel } from '../../../../../services/genre/genre-model';
 import { AddToPlaylistMenu } from '../../../add-to-playlist-menu';
 import { GenresPersister } from '../genres-persister';
-import { GenreOrder } from './genre-order';
+import { GenreOrder, genreOrderKey } from './genre-order';
 import { PlaybackService } from '../../../../../services/playback/playback.service';
 import { SemanticZoomServiceBase } from '../../../../../services/semantic-zoom/semantic-zoom.service.base';
 import { ApplicationServiceBase } from '../../../../../services/application/application.service.base';
@@ -113,20 +113,8 @@ export class GenreBrowserComponent implements OnInit, OnDestroy {
         }
     }
 
-    public toggleGenreOrder(): void {
-        switch (this.selectedGenreOrder) {
-            case GenreOrder.byGenreAscending:
-                this.selectedGenreOrder = GenreOrder.byGenreDescending;
-                break;
-            case GenreOrder.byGenreDescending:
-                this.selectedGenreOrder = GenreOrder.byGenreAscending;
-                break;
-            default: {
-                this.selectedGenreOrder = GenreOrder.byGenreAscending;
-                break;
-            }
-        }
-
+    public applyGenreOrder(genreOrder: GenreOrder): void {
+        this.selectedGenreOrder = genreOrder;
         this.genresPersister.setSelectedGenreOrder(this.selectedGenreOrder);
         this.orderGenres();
     }
@@ -199,4 +187,7 @@ export class GenreBrowserComponent implements OnInit, OnDestroy {
             this.viewPort.scrollToIndex(selectedIndex, 'smooth');
         }
     }
+
+    protected readonly genreOrders: GenreOrder[] = Object.values(GenreOrder).filter((x): x is GenreOrder => typeof x === 'number');
+    protected readonly genreOrderKey = genreOrderKey;
 }

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
@@ -29,6 +29,9 @@ import { Timer } from '../../../../../common/scheduling/timer';
 export class GenreBrowserComponent implements OnInit, OnDestroy {
     @ViewChild(CdkVirtualScrollViewport) public viewPort: CdkVirtualScrollViewport;
 
+    public readonly genreOrders: GenreOrder[] = Object.values(GenreOrder).filter((x): x is GenreOrder => typeof x === 'number');
+    public readonly genreOrderKey = genreOrderKey;
+
     private _genres: GenreModel[] = [];
     private _genresPersister: GenresPersister;
     private subscription: Subscription = new Subscription();
@@ -53,7 +56,6 @@ export class GenreBrowserComponent implements OnInit, OnDestroy {
 
     public orderedGenres: GenreModel[] = [];
 
-    public genreOrderEnum: typeof GenreOrder = GenreOrder;
     public selectedGenreOrder: GenreOrder;
 
     public get genresPersister(): GenresPersister {
@@ -187,7 +189,4 @@ export class GenreBrowserComponent implements OnInit, OnDestroy {
             this.viewPort.scrollToIndex(selectedIndex, 'smooth');
         }
     }
-
-    protected readonly genreOrders: GenreOrder[] = Object.values(GenreOrder).filter((x): x is GenreOrder => typeof x === 'number');
-    protected readonly genreOrderKey = genreOrderKey;
 }

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-browser.component.ts
@@ -113,11 +113,11 @@ export class GenreBrowserComponent implements OnInit, OnDestroy {
         }
     }
 
-    public applyGenreOrder(genreOrder: GenreOrder): void {
+    public applyGenreOrder = (genreOrder: GenreOrder): void => {
         this.selectedGenreOrder = genreOrder;
         this.genresPersister.setSelectedGenreOrder(this.selectedGenreOrder);
         this.orderGenres();
-    }
+    };
 
     public onGenreContextMenu(event: MouseEvent, genre: GenreModel): void {
         this.contextMenuOpener.open(this.genreContextMenu, event, genre);

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-order.spec.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-order.spec.ts
@@ -1,0 +1,23 @@
+import { GenreOrder, genreOrderKey } from './genre-order';
+
+describe('GenreOrder', () => {
+    describe('genreOrderKey', () => {
+        [
+            [GenreOrder.byGenreAscending, 'by-genre-ascending'],
+            [GenreOrder.byGenreDescending, 'by-genre-descending'],
+        ].forEach((pair) => {
+            const artistType = pair[0] as GenreOrder;
+
+            it(`should return genre order key for ${artistType}`, () => {
+                // Arrange
+                const expectedGenreOrderKey = pair[1] as string;
+
+                // Act
+                const result = genreOrderKey(artistType);
+
+                // Assert
+                expect(result).toEqual(expectedGenreOrderKey);
+            });
+        });
+    });
+});

--- a/src/app/ui/components/collection/collection-genres/genre-browser/genre-order.ts
+++ b/src/app/ui/components/collection/collection-genres/genre-browser/genre-order.ts
@@ -2,3 +2,12 @@ export enum GenreOrder {
     byGenreAscending = 1,
     byGenreDescending = 2,
 }
+
+export function genreOrderKey(genreOrder: GenreOrder): string {
+    switch (genreOrder) {
+        case GenreOrder.byGenreAscending:
+            return 'by-genre-ascending';
+        case GenreOrder.byGenreDescending:
+            return 'by-genre-descending';
+    }
+}

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.html
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.html
@@ -14,9 +14,13 @@
                 (click)="createPlaylistAsync()"
             ></app-icon-button>
 
-            <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
-                {{ playlistOrderKey(this.selectedPlaylistOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-            </div>
+            <app-iterable-menu
+                [tooltipKey]="'choose-order'"
+                [currentItem]="selectedPlaylistOrder"
+                [items]="playlistOrders"
+                [itemKeyFn]="playlistOrderKey"
+                [applyItemFn]="applyPlaylistOrder">
+            </app-iterable-menu>
         </div>
     </div>
     <div class="d-flex flex-grow align-items-center justify-content-center" *ngIf="!this.hasPlaylists">
@@ -62,13 +66,4 @@
             <span>{{ 'add-to-playback-queue' | translate }}</span>
         </button>
     </ng-template>
-</mat-menu>
-
-<mat-menu #orderMenu="matMenu">
-    <ng-container *ngFor="let order of playlistOrders; let last = last">
-        <button mat-menu-item (click)="applyPlaylistOrder(order)">
-            {{ playlistOrderKey(order) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.html
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.html
@@ -14,13 +14,8 @@
                 (click)="createPlaylistAsync()"
             ></app-icon-button>
 
-            <div class="pointer" (click)="this.togglePlaylistOrder()">
-                <div class="secondary-text" *ngIf="this.selectedPlaylistOrder === playlistOrderEnum.byPlaylistNameAscending">
-                    {{ 'by-playlist-name-ascending' | translate }}
-                </div>
-                <div class="secondary-text" *ngIf="this.selectedPlaylistOrder === playlistOrderEnum.byPlaylistNameDescending">
-                    {{ 'by-playlist-name-descending' | translate }}
-                </div>
+            <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
+                {{ playlistOrderKey(this.selectedPlaylistOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
             </div>
         </div>
     </div>
@@ -67,4 +62,13 @@
             <span>{{ 'add-to-playback-queue' | translate }}</span>
         </button>
     </ng-template>
+</mat-menu>
+
+<mat-menu #orderMenu="matMenu">
+    <ng-container *ngFor="let order of playlistOrders; let last = last">
+        <button mat-menu-item (click)="applyPlaylistOrder(order)">
+            {{ playlistOrderKey(order) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.spec.ts
@@ -1,3 +1,117 @@
+import { PlaylistBrowserComponent } from './playlist-browser.component';
+import { PlaylistServiceBase } from '../../../../../services/playlist/playlist.service.base';
+import { PlaybackService } from '../../../../../services/playback/playback.service';
+import { IMock, Mock, Times } from 'typemoq';
+import { ApplicationServiceBase } from '../../../../../services/application/application.service.base';
+import { DialogServiceBase } from '../../../../../services/dialog/dialog.service.base';
+import { TranslatorServiceBase } from '../../../../../services/translator/translator.service.base';
+import { PlaylistRowsGetter } from '../playlist-folder-browser/playlist-rows-getter';
+import { NativeElementProxy } from '../../../../../common/native-element-proxy';
+import { MouseSelectionWatcher } from '../../../mouse-selection-watcher';
+import { ContextMenuOpener } from '../../../context-menu-opener';
+import { Logger } from '../../../../../common/logger';
+import { Observable, Subject } from 'rxjs';
+import { PlaylistOrder } from '../playlist-order';
+import { PlaylistsPersister } from '../playlists-persister';
+import { PlaylistModel } from '../../../../../services/playlist/playlist-model';
+import { PlaylistRow } from './playlist-row';
+
 describe('PlaylistBrowserComponent', () => {
-    test.todo('should write tests');
+    let playbackServiceMock: IMock<PlaybackService>;
+    let playlistServiceMock: IMock<PlaylistServiceBase>;
+    let applicationServiceMock: IMock<ApplicationServiceBase>;
+    let translatorServiceMock: IMock<TranslatorServiceBase>;
+    let dialogServiceBaseMock: IMock<DialogServiceBase>;
+    let playlistRowsGetterMock: IMock<PlaylistRowsGetter>;
+    let nativeElementProxyMock: IMock<NativeElementProxy>;
+    let mouseSelectionWatcherMock: IMock<MouseSelectionWatcher>;
+    let contextMenuOpenerMock: IMock<ContextMenuOpener>;
+    let loggerMock: IMock<Logger>;
+
+    let playlistsPersisterMock: IMock<PlaylistsPersister>;
+
+    let windowSizeChanged: Subject<void>;
+    let mouseButtonReleased: Subject<void>;
+    let windowSizeChanged$: Observable<void>;
+    let mouseButtonReleased$: Observable<void>;
+
+    let playlistModel1: PlaylistModel;
+    let playlistModel2: PlaylistModel;
+    let playlistRow: PlaylistRow;
+    let playlistRows: PlaylistRow[];
+
+    function createComponent(): PlaylistBrowserComponent {
+        const result = new PlaylistBrowserComponent(
+            playbackServiceMock.object,
+            playlistServiceMock.object,
+            applicationServiceMock.object,
+            translatorServiceMock.object,
+            dialogServiceBaseMock.object,
+            playlistRowsGetterMock.object,
+            nativeElementProxyMock.object,
+            mouseSelectionWatcherMock.object,
+            contextMenuOpenerMock.object,
+            loggerMock.object,
+        );
+
+        result.playlistsPersister = playlistsPersisterMock.object;
+
+        return result;
+    }
+
+    beforeEach(() => {
+        playbackServiceMock = Mock.ofType<PlaybackService>();
+        playlistServiceMock = Mock.ofType<PlaylistServiceBase>();
+        applicationServiceMock = Mock.ofType<ApplicationServiceBase>();
+        translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
+        dialogServiceBaseMock = Mock.ofType<DialogServiceBase>();
+        playlistRowsGetterMock = Mock.ofType<PlaylistRowsGetter>();
+        nativeElementProxyMock = Mock.ofType<NativeElementProxy>();
+        mouseSelectionWatcherMock = Mock.ofType<MouseSelectionWatcher>();
+        contextMenuOpenerMock = Mock.ofType<ContextMenuOpener>();
+        loggerMock = Mock.ofType<Logger>();
+
+        playlistsPersisterMock = Mock.ofType<PlaylistsPersister>();
+
+        windowSizeChanged = new Subject();
+        mouseButtonReleased = new Subject();
+        windowSizeChanged$ = windowSizeChanged.asObservable();
+        mouseButtonReleased$ = mouseButtonReleased.asObservable();
+        applicationServiceMock.setup((x) => x.windowSizeChanged$).returns(() => windowSizeChanged$);
+        applicationServiceMock.setup((x) => x.mouseButtonReleased$).returns(() => mouseButtonReleased$);
+
+        playlistModel1 = new PlaylistModel('Playlist 1', 'Folder', 'Path 1', 'Image path 1');
+        playlistModel2 = new PlaylistModel('Playlist 2', 'Folder', 'Path 2', 'Image path 2');
+
+        playlistRow = new PlaylistRow();
+        playlistRow.playlists = [playlistModel1, playlistModel2];
+
+        playlistRows = [playlistRow];
+    });
+
+    describe('applyPlaylistOrder', () => {
+        it('should apply playlist order', () => {
+            // Arrange
+            const component = createComponent();
+            const playlists = [playlistModel1, playlistModel2];
+            component.playlists = playlists;
+
+            const playlistOrder = PlaylistOrder.byPlaylistNameAscending;
+            playlistRowsGetterMock.setup((x) => x.getPlaylistRows(0, playlists, playlistOrder)).returns(() => playlistRows);
+
+            playlistsPersisterMock.setup((x) => x.getSelectedPlaylists(playlists)).returns(() => [playlistModel2]);
+
+            // Act
+            component.applyPlaylistOrder(playlistOrder);
+
+            // Assert
+            expect(component.selectedPlaylistOrder).toEqual(playlistOrder);
+            playlistsPersisterMock.verify((x) => x.setSelectedPlaylistOrder(playlistOrder), Times.once());
+            expect(component.playlistRows).toEqual(playlistRows);
+            expect(playlistModel1.isSelected).toBeFalsy();
+            expect(playlistModel2.isSelected).toBeTruthy();
+        });
+    });
+
+    test.todo('should write more tests');
 });

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.spec.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.spec.ts
@@ -11,7 +11,7 @@ import { MouseSelectionWatcher } from '../../../mouse-selection-watcher';
 import { ContextMenuOpener } from '../../../context-menu-opener';
 import { Logger } from '../../../../../common/logger';
 import { Observable, Subject } from 'rxjs';
-import { PlaylistOrder } from '../playlist-order';
+import { PlaylistOrder, playlistOrderKey } from '../playlist-order';
 import { PlaylistsPersister } from '../playlists-persister';
 import { PlaylistModel } from '../../../../../services/playlist/playlist-model';
 import { PlaylistRow } from './playlist-row';
@@ -87,6 +87,28 @@ describe('PlaylistBrowserComponent', () => {
         playlistRow.playlists = [playlistModel1, playlistModel2];
 
         playlistRows = [playlistRow];
+    });
+
+    describe('constructor', () => {
+        it('should define playlistOrders', () => {
+            // Arrange
+
+            // Act
+            const component = createComponent();
+
+            // Assert
+            expect(component.playlistOrders).toEqual([PlaylistOrder.byPlaylistNameAscending, PlaylistOrder.byPlaylistNameDescending]);
+        });
+
+        it('should define playlistOrderKey', () => {
+            // Arrange
+
+            // Act
+            const component = createComponent();
+
+            // Assert
+            expect(component.playlistOrderKey).toEqual(playlistOrderKey);
+        });
     });
 
     describe('applyPlaylistOrder', () => {

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
@@ -26,6 +26,9 @@ import { Constants } from '../../../../../common/application/constants';
     providers: [MouseSelectionWatcher],
 })
 export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDestroy {
+    public readonly playlistOrders: PlaylistOrder[] = Object.values(PlaylistOrder).filter((x): x is PlaylistOrder => typeof x === 'number');
+    public readonly playlistOrderKey = playlistOrderKey;
+
     private _playlists: PlaylistModel[] = [];
     private _playlistsPersister: PlaylistsPersister;
     private availableWidthInPixels: number = 0;
@@ -196,7 +199,4 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
 
         return true;
     }
-
-    protected readonly playlistOrders: PlaylistOrder[] = Object.values(PlaylistOrder).filter((x): x is PlaylistOrder => typeof x === 'number');
-    protected readonly playlistOrderKey = playlistOrderKey;
 }

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
@@ -118,11 +118,11 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
         this.playlistsPersister.setSelectedPlaylists(this.mouseSelectionWatcher.selectedItems as PlaylistModel[]);
     }
 
-    public applyPlaylistOrder(playlistOrder: PlaylistOrder): void {
+    public applyPlaylistOrder = (playlistOrder: PlaylistOrder): void => {
         this.selectedPlaylistOrder = playlistOrder;
         this.playlistsPersister.setSelectedPlaylistOrder(this.selectedPlaylistOrder);
         this.orderPlaylists();
-    }
+    };
 
     public onPlaylistContextMenu(event: MouseEvent, playlist: PlaylistModel): void {
         this.contextMenuOpener.open(this.playlistContextMenu, event, playlist);

--- a/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-browser/playlist-browser.component.ts
@@ -1,10 +1,10 @@
-import { AfterViewInit, Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Logger } from '../../../../../common/logger';
 import { NativeElementProxy } from '../../../../../common/native-element-proxy';
 import { PlaylistModel } from '../../../../../services/playlist/playlist-model';
 import { PlaylistRowsGetter } from '../playlist-folder-browser/playlist-rows-getter';
-import { PlaylistOrder } from '../playlist-order';
+import { PlaylistOrder, playlistOrderKey } from '../playlist-order';
 import { PlaylistsPersister } from '../playlists-persister';
 import { PlaylistRow } from './playlist-row';
 import { PlaybackService } from '../../../../../services/playback/playback.service';
@@ -44,7 +44,6 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
         private logger: Logger,
     ) {}
 
-    public playlistOrderEnum: typeof PlaylistOrder = PlaylistOrder;
     public playlistRows: PlaylistRow[] = [];
 
     public selectedPlaylistOrder: PlaylistOrder;
@@ -119,20 +118,8 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
         this.playlistsPersister.setSelectedPlaylists(this.mouseSelectionWatcher.selectedItems as PlaylistModel[]);
     }
 
-    public togglePlaylistOrder(): void {
-        switch (this.selectedPlaylistOrder) {
-            case PlaylistOrder.byPlaylistNameAscending:
-                this.selectedPlaylistOrder = PlaylistOrder.byPlaylistNameDescending;
-                break;
-            case PlaylistOrder.byPlaylistNameDescending:
-                this.selectedPlaylistOrder = PlaylistOrder.byPlaylistNameAscending;
-                break;
-            default: {
-                this.selectedPlaylistOrder = PlaylistOrder.byPlaylistNameDescending;
-                break;
-            }
-        }
-
+    public applyPlaylistOrder(playlistOrder: PlaylistOrder): void {
+        this.selectedPlaylistOrder = playlistOrder;
         this.playlistsPersister.setSelectedPlaylistOrder(this.selectedPlaylistOrder);
         this.orderPlaylists();
     }
@@ -143,10 +130,6 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
 
     private applySelectedPlaylists(): void {
         const selectedPlaylists: PlaylistModel[] = this.playlistsPersister.getSelectedPlaylists(this.playlists);
-
-        if (selectedPlaylists == undefined) {
-            return;
-        }
 
         for (const selectedPlaylist of selectedPlaylists) {
             selectedPlaylist.isSelected = true;
@@ -213,4 +196,7 @@ export class PlaylistBrowserComponent implements AfterViewInit, OnChanges, OnDes
 
         return true;
     }
+
+    protected readonly playlistOrders: PlaylistOrder[] = Object.values(PlaylistOrder).filter((x): x is PlaylistOrder => typeof x === 'number');
+    protected readonly playlistOrderKey = playlistOrderKey;
 }

--- a/src/app/ui/components/collection/collection-playlists/playlist-order.spec.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-order.spec.ts
@@ -1,0 +1,23 @@
+import { PlaylistOrder, playlistOrderKey } from './playlist-order';
+
+describe('PlaylistOrder', () => {
+    describe('playlistOrderKey', () => {
+        [
+            [PlaylistOrder.byPlaylistNameAscending, 'by-playlist-name-ascending'],
+            [PlaylistOrder.byPlaylistNameDescending, 'by-playlist-name-descending'],
+        ].forEach((pair) => {
+            const playlistOrder = pair[0] as PlaylistOrder;
+
+            it(`should return playlist order key for ${playlistOrder}`, () => {
+                // Arrange
+                const expectedPlaylistOrderKey = pair[1] as string;
+
+                // Act
+                const result = playlistOrderKey(playlistOrder);
+
+                // Assert
+                expect(result).toEqual(expectedPlaylistOrderKey);
+            });
+        });
+    });
+});

--- a/src/app/ui/components/collection/collection-playlists/playlist-order.ts
+++ b/src/app/ui/components/collection/collection-playlists/playlist-order.ts
@@ -2,3 +2,12 @@ export enum PlaylistOrder {
     byPlaylistNameAscending = 1,
     byPlaylistNameDescending = 2,
 }
+
+export function playlistOrderKey(playlistOrder: PlaylistOrder): string {
+    switch (playlistOrder) {
+        case PlaylistOrder.byPlaylistNameAscending:
+            return 'by-playlist-name-ascending';
+        case PlaylistOrder.byPlaylistNameDescending:
+            return 'by-playlist-name-descending';
+    }
+}

--- a/src/app/ui/components/collection/track-browser/track-browser.component.html
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.html
@@ -5,9 +5,13 @@
             <div *ngIf="this.tracks.numberOfTracks === 1">{{ 'track' | translate }}</div>
             <div *ngIf="this.tracks.numberOfTracks !== 1">{{ 'tracks' | translate }}</div>
         </div>
-        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
-            {{ trackOrderKey(this.selectedTrackOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
-        </div>
+        <app-iterable-menu
+            [tooltipKey]="'choose-order'"
+            [currentItem]="selectedTrackOrder"
+            [items]="trackOrders"
+            [itemKeyFn]="trackOrderKey"
+            [applyItemFn]="applyTrackOrder">
+        </app-iterable-menu>
     </div>
     <cdk-virtual-scroll-viewport class="flex-grow mt-3" itemSize="46">
         <div *cdkVirtualFor="let track of this.orderedTracks" (mousedown)="setSelectedTracks($event, track)">
@@ -82,13 +86,4 @@
             </mat-menu>
         </ng-container>
     </div>
-</mat-menu>
-
-<mat-menu #orderMenu="matMenu">
-    <ng-container *ngFor="let order of trackOrders; let last = last">
-        <button mat-menu-item (click)="applyTrackOrder(order)">
-            {{ trackOrderKey(order) | translate }}
-        </button>
-        <mat-divider *ngIf="!last"></mat-divider>
-    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/track-browser/track-browser.component.html
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.html
@@ -5,16 +5,8 @@
             <div *ngIf="this.tracks.numberOfTracks === 1">{{ 'track' | translate }}</div>
             <div *ngIf="this.tracks.numberOfTracks !== 1">{{ 'tracks' | translate }}</div>
         </div>
-        <div class="pointer" (click)="toggleTrackOrder()">
-            <div class="secondary-text" *ngIf="this.selectedTrackOrder === trackOrderEnum.byTrackTitleAscending">
-                {{ 'by-track-title-ascending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedTrackOrder === trackOrderEnum.byTrackTitleDescending">
-                {{ 'by-track-title-descending' | translate }}
-            </div>
-            <div class="secondary-text" *ngIf="this.selectedTrackOrder === trackOrderEnum.byAlbum">
-                {{ 'by-album' | translate }}
-            </div>
+        <div class="window-button order-button" [matMenuTriggerFor]="orderMenu" matTooltip="{{ 'choose-order' | translate }}">
+            {{ trackOrderKey(this.selectedTrackOrder) | translate }}<i class="ml-1 las la-angle-down secondary-text"></i>
         </div>
     </div>
     <cdk-virtual-scroll-viewport class="flex-grow mt-3" itemSize="46">
@@ -90,4 +82,13 @@
             </mat-menu>
         </ng-container>
     </div>
+</mat-menu>
+
+<mat-menu #orderMenu="matMenu">
+    <ng-container *ngFor="let order of trackOrders; let last = last">
+        <button mat-menu-item (click)="applyTrackOrder(order)">
+            {{ trackOrderKey(order) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
 </mat-menu>

--- a/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
@@ -180,16 +180,6 @@ describe('TrackBrowserComponent', () => {
             expect(component).toBeDefined();
         });
 
-        it('should define trackOrderEnum', () => {
-            // Arrange
-
-            // Act
-            const component: TrackBrowserComponent = createComponent();
-
-            // Assert
-            expect(component.trackOrderEnum).toBeDefined();
-        });
-
         it('should define tracks as empty', () => {
             // Arrange
 
@@ -401,19 +391,45 @@ describe('TrackBrowserComponent', () => {
         });
     });
 
-    describe('toggleTrackOrder', () => {
-        it('should change TrackOrder from byTrackTitleAscending to byTrackTitleDescending', () => {
+    describe('applyTrackOrder', () => {
+        it('should apply track order by track title ascending', () => {
+            // Arrange
+            const component: TrackBrowserComponent = createComponent();
+            component.tracksPersister = tracksPersisterMock.object;
+            component.selectedTrackOrder = TrackOrder.byTrackTitleDescending;
+            component.tracks = tracks;
+
+            const trackOrder = TrackOrder.byTrackTitleAscending;
+
+            // Act
+            component.applyTrackOrder(trackOrder);
+
+            // Assert
+            expect(component.selectedTrackOrder).toEqual(trackOrder);
+            expect(component.orderedTracks[0]).toBe(trackModel1);
+            expect(component.orderedTracks[0].showHeader).toBeFalsy();
+            expect(component.orderedTracks[1]).toBe(trackModel2);
+            expect(component.orderedTracks[1].showHeader).toBeFalsy();
+            expect(component.orderedTracks[2]).toBe(trackModel3);
+            expect(component.orderedTracks[2].showHeader).toBeFalsy();
+            expect(component.orderedTracks[3]).toBe(trackModel4);
+            expect(component.orderedTracks[3].showHeader).toBeFalsy();
+        });
+
+        it('should apply track order by track title descending', () => {
             // Arrange
             const component: TrackBrowserComponent = createComponent();
             component.tracksPersister = tracksPersisterMock.object;
             component.selectedTrackOrder = TrackOrder.byTrackTitleAscending;
             component.tracks = tracks;
 
+            const trackOrder = TrackOrder.byTrackTitleDescending;
+
             // Act
-            component.toggleTrackOrder();
+            component.applyTrackOrder(trackOrder);
 
             // Assert
-            expect(component.selectedTrackOrder).toEqual(TrackOrder.byTrackTitleDescending);
+            expect(component.selectedTrackOrder).toEqual(trackOrder);
             expect(component.orderedTracks[0]).toBe(trackModel4);
             expect(component.orderedTracks[0].showHeader).toBeFalsy();
             expect(component.orderedTracks[1]).toBe(trackModel3);
@@ -424,18 +440,20 @@ describe('TrackBrowserComponent', () => {
             expect(component.orderedTracks[3].showHeader).toBeFalsy();
         });
 
-        it('should change TrackOrder from byTrackTitleDescending to byAlbum', () => {
+        it('should apply track order by album', () => {
             // Arrange
             const component: TrackBrowserComponent = createComponent();
             component.tracksPersister = tracksPersisterMock.object;
             component.selectedTrackOrder = TrackOrder.byTrackTitleDescending;
             component.tracks = tracks;
 
+            const trackOrder = TrackOrder.byAlbum;
+
             // Act
-            component.toggleTrackOrder();
+            component.applyTrackOrder(trackOrder);
 
             // Assert
-            expect(component.selectedTrackOrder).toEqual(TrackOrder.byAlbum);
+            expect(component.selectedTrackOrder).toEqual(trackOrder);
             expect(component.orderedTracks[0]).toBe(trackModel1);
             expect(component.orderedTracks[0].showHeader).toBeTruthy();
             expect(component.orderedTracks[1]).toBe(trackModel2);
@@ -446,49 +464,28 @@ describe('TrackBrowserComponent', () => {
             expect(component.orderedTracks[3].showHeader).toBeFalsy();
         });
 
-        it('should change TrackOrder from byAlbum to byTrackTitleAscending', () => {
-            // Arrange
-            const component: TrackBrowserComponent = createComponent();
-            component.tracksPersister = tracksPersisterMock.object;
-            component.selectedTrackOrder = TrackOrder.byAlbum;
-            component.tracks = tracks;
-
-            // Act
-            component.toggleTrackOrder();
-
-            // Assert
-            expect(component.selectedTrackOrder).toEqual(TrackOrder.byTrackTitleAscending);
-            expect(component.orderedTracks[0]).toBe(trackModel1);
-            expect(component.orderedTracks[0].showHeader).toBeFalsy();
-            expect(component.orderedTracks[1]).toBe(trackModel2);
-            expect(component.orderedTracks[1].showHeader).toBeFalsy();
-            expect(component.orderedTracks[2]).toBe(trackModel3);
-            expect(component.orderedTracks[2].showHeader).toBeFalsy();
-            expect(component.orderedTracks[3]).toBe(trackModel4);
-            expect(component.orderedTracks[3].showHeader).toBeFalsy();
-        });
-
         it('should persist the selected track order', () => {
             // Arrange
             const component: TrackBrowserComponent = createComponent();
             component.tracksPersister = tracksPersisterMock.object;
             component.selectedTrackOrder = TrackOrder.byAlbum;
 
+            const trackOrder = TrackOrder.byTrackTitleAscending;
+
             // Act
-            component.toggleTrackOrder();
+            component.applyTrackOrder(trackOrder);
 
             // Assert
-            tracksPersisterMock.verify((x) => x.setSelectedTrackOrder(TrackOrder.byTrackTitleAscending), Times.exactly(1));
+            tracksPersisterMock.verify((x) => x.setSelectedTrackOrder(trackOrder), Times.exactly(1));
         });
 
         it('should set the playing track', () => {
             // Arrange
             const component: TrackBrowserComponent = createComponent();
             component.tracksPersister = tracksPersisterMock.object;
-            component.selectedTrackOrder = TrackOrder.byAlbum;
 
             // Act
-            component.toggleTrackOrder();
+            component.applyTrackOrder(TrackOrder.byAlbum);
 
             // Assert
             playbackIndicationServiceMock.verify((x) => x.setPlayingTrack(component.orderedTracks, trackModel1), Times.exactly(1));

--- a/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
@@ -4,7 +4,7 @@ import { Track } from '../../../../data/entities/track';
 import { TrackModel } from '../../../../services/track/track-model';
 import { AddToPlaylistMenu } from '../../add-to-playlist-menu';
 import { BaseTracksPersister } from '../base-tracks-persister';
-import { TrackOrder } from '../track-order';
+import { TrackOrder, trackOrderKey } from '../track-order';
 import { TrackBrowserComponent } from './track-browser.component';
 import { TrackModels } from '../../../../services/track/track-models';
 import { PlaybackStarted } from '../../../../services/playback/playback-started';
@@ -219,6 +219,30 @@ describe('TrackBrowserComponent', () => {
 
             // Assert
             expect(component.trackContextMenu).toBeUndefined();
+        });
+
+        it('should define trackOrders', () => {
+            // Arrange
+
+            // Act
+            const component: TrackBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.trackOrders).toEqual([
+                TrackOrder.byTrackTitleAscending,
+                TrackOrder.byTrackTitleDescending,
+                TrackOrder.byAlbum,
+            ]);
+        });
+
+        it('should define trackOrderKey', () => {
+            // Arrange
+
+            // Act
+            const component: TrackBrowserComponent = createComponent();
+
+            // Assert
+            expect(component.trackOrderKey).toEqual(trackOrderKey);
         });
     });
 

--- a/src/app/ui/components/collection/track-browser/track-browser.component.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.ts
@@ -142,11 +142,11 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
         this.mouseSelectionWatcher.setSelectedItems(event, trackToSelect);
     }
 
-    public applyTrackOrder(trackOrder: TrackOrder): void {
+    public applyTrackOrder = (trackOrder: TrackOrder): void => {
         this.selectedTrackOrder = trackOrder;
         this.tracksPersister.setSelectedTrackOrder(this.selectedTrackOrder);
         this.orderTracks();
-    }
+    };
 
     private orderTracks(): void {
         let orderedTracks: TrackModel[] = [];

--- a/src/app/ui/components/collection/track-browser/track-browser.component.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.ts
@@ -8,7 +8,7 @@ import { TrackModel } from '../../../../services/track/track-model';
 import { TrackModels } from '../../../../services/track/track-models';
 import { AddToPlaylistMenu } from '../../add-to-playlist-menu';
 import { BaseTracksPersister } from '../base-tracks-persister';
-import { TrackOrder } from '../track-order';
+import { TrackOrder, trackOrderKey } from '../track-order';
 import { TrackBrowserBase } from './track-brower-base';
 import { PlaybackIndicationServiceBase } from '../../../../services/playback-indication/playback-indication.service.base';
 import { CollectionServiceBase } from '../../../../services/collection/collection.service.base';
@@ -68,7 +68,6 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
 
     public orderedTracks: TrackModel[] = [];
 
-    public trackOrderEnum: typeof TrackOrder = TrackOrder;
     public selectedTrackOrder: TrackOrder;
 
     public get tracksPersister(): BaseTracksPersister {
@@ -143,23 +142,8 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
         this.mouseSelectionWatcher.setSelectedItems(event, trackToSelect);
     }
 
-    public toggleTrackOrder(): void {
-        switch (this.selectedTrackOrder) {
-            case TrackOrder.byTrackTitleAscending:
-                this.selectedTrackOrder = TrackOrder.byTrackTitleDescending;
-                break;
-            case TrackOrder.byTrackTitleDescending:
-                this.selectedTrackOrder = TrackOrder.byAlbum;
-                break;
-            case TrackOrder.byAlbum:
-                this.selectedTrackOrder = TrackOrder.byTrackTitleAscending;
-                break;
-            default: {
-                this.selectedTrackOrder = TrackOrder.byTrackTitleAscending;
-                break;
-            }
-        }
-
+    public applyTrackOrder(trackOrder: TrackOrder): void {
+        this.selectedTrackOrder = trackOrder;
         this.tracksPersister.setSelectedTrackOrder(this.selectedTrackOrder);
         this.orderTracks();
     }
@@ -230,4 +214,11 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
             previousDiscNumber = track.discNumber;
         }
     }
+
+    protected readonly trackOrders: TrackOrder[] = [
+        TrackOrder.byTrackTitleAscending,
+        TrackOrder.byTrackTitleDescending,
+        TrackOrder.byAlbum,
+    ];
+    protected readonly trackOrderKey = trackOrderKey;
 }

--- a/src/app/ui/components/collection/track-browser/track-browser.component.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.ts
@@ -31,6 +31,9 @@ import { MetadataService } from '../../../../services/metadata/metadata.service'
     encapsulation: ViewEncapsulation.None,
 })
 export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, OnDestroy {
+    public readonly trackOrders: TrackOrder[] = [TrackOrder.byTrackTitleAscending, TrackOrder.byTrackTitleDescending, TrackOrder.byAlbum];
+    public readonly trackOrderKey = trackOrderKey;
+
     private _tracks: TrackModels = new TrackModels();
     private _tracksPersister: BaseTracksPersister;
     private subscription: Subscription = new Subscription();
@@ -214,11 +217,4 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
             previousDiscNumber = track.discNumber;
         }
     }
-
-    protected readonly trackOrders: TrackOrder[] = [
-        TrackOrder.byTrackTitleAscending,
-        TrackOrder.byTrackTitleDescending,
-        TrackOrder.byAlbum,
-    ];
-    protected readonly trackOrderKey = trackOrderKey;
 }

--- a/src/app/ui/components/collection/track-order.spec.ts
+++ b/src/app/ui/components/collection/track-order.spec.ts
@@ -1,0 +1,26 @@
+import { TrackOrder, trackOrderKey } from './track-order';
+
+describe('TrackOrder', () => {
+    describe('trackOrderKey', () => {
+        [
+            [TrackOrder.byTrackTitleAscending, 'by-track-title-ascending'],
+            [TrackOrder.byTrackTitleDescending, 'by-track-title-descending'],
+            [TrackOrder.byAlbum, 'by-album'],
+            [TrackOrder.byRating, 'by-rating'],
+            [TrackOrder.none, ''],
+        ].forEach((pair) => {
+            const trackOrder = pair[0] as TrackOrder;
+
+            it(`should return track order key for ${trackOrder}`, () => {
+                // Arrange
+                const expectedTrackOrderKey = pair[1] as string;
+
+                // Act
+                const result = trackOrderKey(trackOrder);
+
+                // Assert
+                expect(result).toEqual(expectedTrackOrderKey);
+            });
+        });
+    });
+});

--- a/src/app/ui/components/collection/track-order.ts
+++ b/src/app/ui/components/collection/track-order.ts
@@ -5,3 +5,18 @@ export enum TrackOrder {
     byRating = 4,
     none = 5,
 }
+
+export function trackOrderKey(trackOrder: TrackOrder): string {
+    switch (trackOrder) {
+        case TrackOrder.byTrackTitleAscending:
+            return 'by-track-title-ascending';
+        case TrackOrder.byTrackTitleDescending:
+            return 'by-track-title-descending';
+        case TrackOrder.byAlbum:
+            return 'by-album';
+        case TrackOrder.byRating:
+            return 'by-rating';
+        case TrackOrder.none:
+            return '';
+    }
+}

--- a/src/app/ui/components/common/iterable-menu.component.css
+++ b/src/app/ui/components/common/iterable-menu.component.css
@@ -1,0 +1,5 @@
+.iterable-menu-button {
+    width: fit-content !important;
+    padding: 5px;
+    cursor: pointer;
+}

--- a/src/app/ui/components/common/iterable-menu.component.html
+++ b/src/app/ui/components/common/iterable-menu.component.html
@@ -1,4 +1,4 @@
-<div class="window-button order-button"
+<div class="window-button iterable-menu-button"
      [matMenuTriggerFor]="itemMenu"
      matTooltip="{{ tooltipKey | translate }}">
     {{ itemKeyFn(currentItem) | translate }}

--- a/src/app/ui/components/common/iterable-menu.component.html
+++ b/src/app/ui/components/common/iterable-menu.component.html
@@ -1,0 +1,15 @@
+<div class="window-button order-button"
+     [matMenuTriggerFor]="itemMenu"
+     matTooltip="{{ tooltipKey | translate }}">
+    {{ itemKeyFn(currentItem) | translate }}
+    <i class="ml-1 las la-angle-down secondary-text"></i>
+</div>
+
+<mat-menu #itemMenu="matMenu">
+    <ng-container *ngFor="let item of items; let last = last">
+        <button mat-menu-item (click)="applyItemFn(item)">
+            {{ itemKeyFn(item) | translate }}
+        </button>
+        <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
+</mat-menu>

--- a/src/app/ui/components/common/iterable-menu.component.ts
+++ b/src/app/ui/components/common/iterable-menu.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'app-iterable-menu',
+    templateUrl: './iterable-menu.component.html',
+})
+export class IterableMenuComponent<T> {
+    @Input() public tooltipKey!: string;
+    @Input() public currentItem!: T;
+    @Input() public items: T[] = [];
+    @Input() public itemKeyFn!: (item: T) => string;
+    @Input() public applyItemFn!: (item: T) => void;
+}

--- a/src/app/ui/components/common/iterable-menu.component.ts
+++ b/src/app/ui/components/common/iterable-menu.component.ts
@@ -3,6 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'app-iterable-menu',
     templateUrl: './iterable-menu.component.html',
+    styleUrls: ['./iterable-menu.component.css'],
 })
 export class IterableMenuComponent<T> {
     @Input() public tooltipKey!: string;

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -316,5 +316,6 @@
     "Information": "Información",
     "no-image-found-online": "No se pudo encontrar ninguna imagen en línea.",
     "image": "Imagen",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -315,5 +315,6 @@
     "download-image-error": "Ocurrió un error al descargar la imagen. Por favor, verifique el archivo de registro si necesita más información.",
     "Information": "Información",
     "no-image-found-online": "No se pudo encontrar ninguna imagen en línea.",
-    "image": "Imagen"
+    "image": "Imagen",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "Aucune image n'a été trouvée en ligne",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -315,5 +315,6 @@
     "download-image-error": "Une erreur s'est produite lors du téléchargement de l'image. Veuillez vérifier le log si vous avez besoin de plus d'informations.",
     "Information": "Information",
     "no-image-found-online": "Aucune image n'a été trouvée en ligne",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/ku.json
+++ b/src/assets/i18n/ku.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/ku.json
+++ b/src/assets/i18n/ku.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -316,5 +316,6 @@
     "Information": "Informatie",
     "no-image-found-online": "Geen afbeelding gevonden",
     "image": "Afbeelding",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -315,5 +315,6 @@
     "download-image-error": "Er is een fout opgetreden bij het downloaden van de afbeelding. Controleer de log als u meer informatie nodig heeft.",
     "Information": "Informatie",
     "no-image-found-online": "Geen afbeelding gevonden",
-    "image": "Afbeelding"
+    "image": "Afbeelding",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -315,5 +315,6 @@
     "download-image-error": "Ocorreu um erro ao baixar a imagem. Verifique o arquivo de log para obter mais informações.",
     "Information": "Informação",
     "no-image-found-online": "Nenhuma imagem foi encontrada online.",
-    "image": "Imagem"
+    "image": "Imagem",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -316,5 +316,6 @@
     "Information": "Informação",
     "no-image-found-online": "Nenhuma imagem foi encontrada online.",
     "image": "Imagem",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -316,5 +316,6 @@
   "Information": "Information",
   "no-image-found-online": "No image could be found online.",
   "image": "Image",
-  "choose-order": "Choose an order"
+  "choose-order": "Choose an order",
+  "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -315,5 +315,6 @@
   "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
   "Information": "Information",
   "no-image-found-online": "No image could be found online.",
-  "image": "Image"
+  "image": "Image",
+  "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -316,5 +316,6 @@
     "Information": "Thông tin",
     "no-image-found-online": "Không tìm thấy ảnh online hợp lệ.",
     "image": "Ảnh",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -315,5 +315,6 @@
     "download-image-error": "Đã xảy ra lỗi khi tải xuống ảnh. Vui lòng xem tập tin log để biết thêm thông tin.",
     "Information": "Thông tin",
     "no-image-found-online": "Không tìm thấy ảnh online hợp lệ.",
-    "image": "Ảnh"
+    "image": "Ảnh",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/assets/i18n/zh-TW.json
+++ b/src/assets/i18n/zh-TW.json
@@ -315,5 +315,6 @@
     "download-image-error": "An error occurred while downloading the image. Please check the log file if you need more information.",
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
-    "image": "Image"
+    "image": "Image",
+    "choose-order": "Choose an order"
 }

--- a/src/assets/i18n/zh-TW.json
+++ b/src/assets/i18n/zh-TW.json
@@ -316,5 +316,6 @@
     "Information": "Information",
     "no-image-found-online": "No image could be found online.",
     "image": "Image",
-    "choose-order": "Choose an order"
+    "choose-order": "Choose an order",
+    "choose-type": "Choose a type"
 }

--- a/src/css/window-buttons.scss
+++ b/src/css/window-buttons.scss
@@ -23,9 +23,3 @@
     fill: var(--theme-highlight-foreground) !important;
     color: var(--theme-highlight-foreground) !important;
 }
-
-.order-button {
-    width: fit-content !important;
-    padding: 5px;
-    cursor: pointer;
-}

--- a/src/css/window-buttons.scss
+++ b/src/css/window-buttons.scss
@@ -23,3 +23,9 @@
     fill: var(--theme-highlight-foreground) !important;
     color: var(--theme-highlight-foreground) !important;
 }
+
+.order-button {
+    width: fit-content !important;
+    padding: 5px;
+    cursor: pointer;
+}


### PR DESCRIPTION
I find it more useful to have album order options as a menu instead of toggling them.
If the solutions is accepted, I propose to apply the same approach for other orders: artist, genre, track, playlist.

<details>
<summary>Result</summary>

Down arrow, hover + translated tooltip
![order-menu-tooltip](https://github.com/user-attachments/assets/0304bf57-9d82-4344-a325-608f139bb00a)

Divided translated options
![order-menu](https://github.com/user-attachments/assets/8fce445c-7dce-4647-85bb-e6d2aa253ac4)

</details>