### PR TITLE
Don't set mat-mdc-dialog background-color and keep it transparent as default

### DIFF
--- a/src/css/angular-material-mods.scss
+++ b/src/css/angular-material-mods.scss
@@ -19,9 +19,6 @@
     background-color: var(--theme-side-pane-background) !important;
 }
 
-.mat-mdc-dialog-container {
-    background-color: var(--theme-dialog-background) !important;
-}
 .mat-mdc-select-panel {
     background-color: var(--theme-dialog-background) !important;
 }


### PR DESCRIPTION
- `mat-mdc-dialog-container` is transparent by default
- currently we set `background-color` to `mat-mdc-dialog-container` and it doesn't look as intended because there is a rectangle under `mat-mdc-dialog-surface`
- it should fix all dialogs within Dopamine

<details>
<summary>Before</summary>

![dialog-before-original](https://github.com/user-attachments/assets/f318422d-e121-46ec-998a-42d3e35618b7)

![dialog-before-original](https://github.com/user-attachments/assets/8317cf86-c0fd-4177-8417-83b615e039b7)

</details>

<details>

<summary>Before with red background for better understanding</summary>

![dialog-before-red-bg](https://github.com/user-attachments/assets/dca5318a-e76a-486c-a0f7-9ffec2158afe)

![dialog-before-red-bg](https://github.com/user-attachments/assets/cbbe352c-2111-415c-b496-8ffa714725ab)

</details>

<details>
<summary>After</summary>

![dialog-after](https://github.com/user-attachments/assets/64792ad2-6a75-4c2a-95cd-8449c8384603)

![dialog-after](https://github.com/user-attachments/assets/47df5d17-d881-4d2a-b5b9-e41ac777ce79)

</details>