### PR TITLE
Refactor SearchBoxComponent

### DIFF
--- a/src/app/common/io/document-proxy.ts
+++ b/src/app/common/io/document-proxy.ts
@@ -13,4 +13,8 @@ export class DocumentProxy {
     public getCanvasById(canvasId: string): HTMLCanvasElement {
         return document.getElementById(canvasId) as HTMLCanvasElement;
     }
+
+    public getActiveElement(): Element | null {
+        return document.activeElement;
+    }
 }

--- a/src/app/ui/components/search-box/search-box.component.html
+++ b/src/app/ui/components/search-box/search-box.component.html
@@ -1,5 +1,5 @@
 <div class="app-search-box" [ngClass]="{ 'app-search-box-highlight': this.searchService.hasSearchText }">
-    <input id="app-search-box" class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" />
+    <input #appSearchBox class="app-search-box__input p-1" [(ngModel)]="this.searchService.searchText" />
     <div class="app-search-box__icons">
         <i class="las la-search app-search-box-icon" *ngIf="!this.searchService.hasSearchText"></i>
         <i class="las la-times app-search-box-icon pointer" *ngIf="this.searchService.hasSearchText" (click)="clearSearchText()"></i>

--- a/src/app/ui/components/search-box/search-box.component.spec.ts
+++ b/src/app/ui/components/search-box/search-box.component.spec.ts
@@ -1,15 +1,31 @@
 import { IMock, Mock, Times } from 'typemoq';
 import { SearchBoxComponent } from './search-box.component';
 import { SearchServiceBase } from '../../../services/search/search.service.base';
+import { ElementRef } from '@angular/core';
+import { DocumentProxy } from '../../../common/io/document-proxy';
 
 describe('SearchBoxComponent', () => {
     let searchServiceMock: IMock<SearchServiceBase>;
+    let documentProxyMock: IMock<DocumentProxy>;
+    let appSearchBoxRefMock: IMock<ElementRef>;
+    let appSearchBoxMock: IMock<HTMLInputElement>;
     let component: SearchBoxComponent;
 
     beforeEach(() => {
         searchServiceMock = Mock.ofType<SearchServiceBase>();
-        component = new SearchBoxComponent(searchServiceMock.object);
+        documentProxyMock = Mock.ofType<DocumentProxy>();
+        appSearchBoxRefMock = Mock.ofType<ElementRef>();
+        appSearchBoxMock = Mock.ofType<HTMLInputElement>();
+
+        appSearchBoxRefMock.setup((x) => x.nativeElement).returns(() => appSearchBoxMock.object);
+
+        component = createComponent();
+        component.appSearchBoxRef = appSearchBoxRefMock.object;
     });
+
+    function createComponent(): SearchBoxComponent {
+        return new SearchBoxComponent(searchServiceMock.object, documentProxyMock.object);
+    }
 
     describe('constructor', () => {
         it('should create', () => {
@@ -29,6 +45,15 @@ describe('SearchBoxComponent', () => {
             // Assert
             expect(component.searchService).toBeDefined();
         });
+
+        it('should define appSearchBoxRef', () => {
+            // Arrange
+
+            // Act
+
+            // Assert
+            expect(component.appSearchBoxRef).toBeDefined();
+        });
     });
 
     describe('clearSearchText', () => {
@@ -44,27 +69,32 @@ describe('SearchBoxComponent', () => {
     });
 
     describe('handleKeyboardEvent', () => {
-        const appSearchBoxId = 'app-search-box';
-
-        afterEach(() => {
-            const appSearchBox = document.getElementById(appSearchBoxId);
-            if (appSearchBox) {
-                document.body.removeChild(appSearchBox);
-            }
-        });
-
-        it(`should blur #${appSearchBoxId} input on Escape key press`, () => {
+        it('should do nothing when appSearchBoxRef is undefined', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            component = createComponent();
 
             const event = new KeyboardEvent('keydown', {
                 key: 'Escape',
             });
-            Object.defineProperty(event, 'target', { value: appSearchBox });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(component.appSearchBoxRef).toBeUndefined();
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
+        });
+
+        it('should blur appSearchBox on Escape', () => {
+            // Arrange
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => appSearchBoxMock.object);
+
+            const event = new KeyboardEvent('keydown', {
+                key: 'Escape',
+            });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
             // Act
@@ -72,22 +102,17 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
-            expect(blurSpy).toHaveBeenCalledTimes(1);
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.once());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not blur #${appSearchBoxId} input on not Escape key press`, () => {
+        it('should not blur appSearchBox on non-Escape', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => appSearchBoxMock.object);
 
             const event = new KeyboardEvent('keydown', {
                 key: 'a',
             });
-            Object.defineProperty(event, 'target', { value: appSearchBox });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
             // Act
@@ -95,22 +120,17 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it('should not blur other inputs on Escape key press', () => {
+        it('should not blur non-active appSearchBox on Escape', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = 'other-input';
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 key: 'Escape',
             });
-            Object.defineProperty(event, 'target', { value: appSearchBox });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
             // Act
@@ -118,25 +138,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
-
-            document.body.removeChild(appSearchBox);
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should focus #${appSearchBoxId} input on Ctrl+KeyF`, () => {
+        it('should focus appSearchBox on Ctrl+KeyF', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: true,
                 metaKey: false,
                 shiftKey: false,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -145,23 +160,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).toHaveBeenCalledTimes(1);
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.once());
         });
 
-        it(`should focus #${appSearchBoxId} input on Meta+KeyF (macOS)`, () => {
+        it('should focus appSearchBox on Meta+KeyF (macOS)', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: false,
                 metaKey: true,
                 shiftKey: false,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -170,25 +182,21 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).toHaveBeenCalledTimes(1);
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.once());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Ctrl+KeyF if target is #${appSearchBoxId}`, () => {
+        it('should not focus appSearchBox on Ctrl+KeyF if appSearchBox is active', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => appSearchBoxMock.object);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: true,
                 metaKey: false,
                 shiftKey: false,
+                altKey: false,
             });
-            Object.defineProperty(event, 'target', { value: appSearchBox });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
             // Act
@@ -196,25 +204,21 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Meta+KeyF (macOS) if target is #${appSearchBoxId}`, () => {
+        it('should not focus appSearchBox on Meta+KeyF (macOS) if appSearchBox is active', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => appSearchBoxMock.object);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: false,
                 metaKey: true,
                 shiftKey: false,
+                altKey: false,
             });
-            Object.defineProperty(event, 'target', { value: appSearchBox });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
             // Act
@@ -222,23 +226,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Ctrl+Shift+KeyF`, () => {
+        it('should not focus appSearchBox on Ctrl+Shift+KeyF', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: true,
                 metaKey: false,
                 shiftKey: true,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -247,23 +248,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Meta+Shift+KeyF (macOS)`, () => {
+        it('should not focus appSearchBox on Meta+Shift+KeyF (macOS)', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: false,
                 metaKey: true,
                 shiftKey: true,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -272,23 +270,108 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Ctrl+non-KeyF`, () => {
+        it('should not focus appSearchBox on Ctrl+Alt+KeyF', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: false,
+                altKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
+        });
+
+        it('should not focus appSearchBox on Meta+Alt+KeyF (macOS)', () => {
+            // Arrange
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: false,
+                altKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
+        });
+
+        it('should not focus appSearchBox on Ctrl+Alt+Shift+KeyF', () => {
+            // Arrange
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: true,
+                metaKey: false,
+                shiftKey: true,
+                altKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
+        });
+
+        it('should not focus appSearchBox on Meta+Alt+Shift+KeyF (macOS)', () => {
+            // Arrange
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
+
+            const event = new KeyboardEvent('keydown', {
+                code: 'KeyF',
+                ctrlKey: false,
+                metaKey: true,
+                shiftKey: true,
+                altKey: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            // Act
+            component.handleKeyboardEvent(event);
+
+            // Assert
+            expect(preventDefaultSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
+        });
+
+        it('should not focus appSearchBox on Ctrl+non-KeyF', () => {
+            // Arrange
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyA',
                 ctrlKey: true,
                 metaKey: false,
                 shiftKey: false,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -297,23 +380,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on Meta+non-KeyF (macOS)`, () => {
+        it('should not focus appSearchBox on Meta+non-KeyF (macOS)', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyA',
                 ctrlKey: false,
                 metaKey: true,
                 shiftKey: false,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -322,23 +402,20 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
 
-        it(`should not focus #${appSearchBoxId} input on KeyF`, () => {
+        it('should not focus appSearchBox on KeyF', () => {
             // Arrange
-            const appSearchBox = document.createElement('input');
-            appSearchBox.id = appSearchBoxId;
-            document.body.appendChild(appSearchBox);
-            const blurSpy = jest.spyOn(appSearchBox, 'blur');
-            const focusSpy = jest.spyOn(appSearchBox, 'focus');
+            documentProxyMock.setup((x) => x.getActiveElement()).returns(() => null);
 
             const event = new KeyboardEvent('keydown', {
                 code: 'KeyF',
                 ctrlKey: false,
                 metaKey: false,
                 shiftKey: false,
+                altKey: false,
             });
             const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -347,8 +424,8 @@ describe('SearchBoxComponent', () => {
 
             // Assert
             expect(preventDefaultSpy).not.toHaveBeenCalled();
-            expect(blurSpy).not.toHaveBeenCalled();
-            expect(focusSpy).not.toHaveBeenCalled();
+            appSearchBoxMock.verify((x) => x.blur(), Times.never());
+            appSearchBoxMock.verify((x) => x.focus(), Times.never());
         });
     });
 });


### PR DESCRIPTION
- replace the search input querying via `document` with `@ViewChild ElementRef`
- interact with `document` via `DocumentProxy`
- do not focus the search input if `Alt` is pressed
- adjust tests and add new ones