### PR TITLE
Override tracks' showHeader

### DIFF
--- a/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.spec.ts
@@ -488,6 +488,43 @@ describe('TrackBrowserComponent', () => {
             expect(component.orderedTracks[3].showHeader).toBeFalsy();
         });
 
+        it('should apply track order by album and override showHeader', () => {
+            // Arrange
+            const component: TrackBrowserComponent = createComponent();
+            component.tracksPersister = tracksPersisterMock.object;
+            component.selectedTrackOrder = TrackOrder.byTrackTitleDescending;
+            component.tracks = tracks;
+            track1.albumKey = 'albumKey1';
+            track1.discNumber = 1;
+            trackModel1.showHeader = false;
+            track2.albumKey = 'albumKey1';
+            track2.discNumber = 1;
+            trackModel2.showHeader = true;
+
+            track3.albumKey = 'albumKey2';
+            track3.discNumber = 1;
+            trackModel3.showHeader = false;
+            track4.albumKey = 'albumKey2';
+            track4.discNumber = 2;
+            trackModel4.showHeader = false;
+
+            const trackOrder = TrackOrder.byAlbum;
+
+            // Act
+            component.applyTrackOrder(trackOrder);
+
+            // Assert
+            expect(component.selectedTrackOrder).toEqual(trackOrder);
+            expect(component.orderedTracks[0]).toBe(trackModel1);
+            expect(component.orderedTracks[0].showHeader).toBeTruthy();
+            expect(component.orderedTracks[1]).toBe(trackModel2);
+            expect(component.orderedTracks[1].showHeader).toBeFalsy();
+            expect(component.orderedTracks[2]).toBe(trackModel3);
+            expect(component.orderedTracks[2].showHeader).toBeTruthy();
+            expect(component.orderedTracks[3]).toBe(trackModel4);
+            expect(component.orderedTracks[3].showHeader).toBeTruthy();
+        });
+
         it('should persist the selected track order', () => {
             // Arrange
             const component: TrackBrowserComponent = createComponent();

--- a/src/app/ui/components/collection/track-browser/track-browser.component.ts
+++ b/src/app/ui/components/collection/track-browser/track-browser.component.ts
@@ -209,12 +209,13 @@ export class TrackBrowserComponent extends TrackBrowserBase implements OnInit, O
         let previousDiscNumber: number = -1;
 
         for (const track of orderedTracks) {
-            if (track.albumKey !== previousAlbumKey || track.discNumber !== previousDiscNumber) {
-                track.showHeader = true;
-            }
+            const albumKey = track.albumKey;
+            const discNumber = track.discNumber;
 
-            previousAlbumKey = track.albumKey;
-            previousDiscNumber = track.discNumber;
+            track.showHeader = albumKey !== previousAlbumKey || discNumber !== previousDiscNumber;
+
+            previousAlbumKey = albumKey;
+            previousDiscNumber = discNumber;
         }
     }
 }


### PR DESCRIPTION
Currently after a successful search `showHeader` is set to true and stays after we reset the search producing album header duplication.

<details>
<summary>Before</summary>

![track-album-header-issue](https://github.com/user-attachments/assets/4343b7c7-755c-44f9-81ad-70690754880f)

</details>

<details>
<summary>After</summary>

![track-album-header-fixed](https://github.com/user-attachments/assets/43c19d11-68c8-4021-862f-ffdf1365d42a)

![track-album-header-fixed-2](https://github.com/user-attachments/assets/edca0c22-2f17-46a6-9804-efa65497b35a)

</details>