### PR TITLE
Fix unknown genre/artist handling

### DIFF
--- a/main/background-work/indexing/data-delimiter.js
+++ b/main/background-work/indexing/data-delimiter.js
@@ -22,22 +22,8 @@ class DataDelimiter {
         return result.join('');
     }
 
-    static fromDelimitedString(delimitedString) {
-        if (delimitedString === undefined || delimitedString.length === 0) {
-            return [];
-        }
-
-        const delimitedStrings = delimitedString.split(DataDelimiter.delimiter);
-
-        return delimitedStrings.filter((x) => x !== '').map((x) => this.removeDelimiters(x));
-    }
-
     static addDelimiters(originalString) {
         return `${this.delimiter}${originalString}${this.delimiter}`;
-    }
-
-    static removeDelimiters(delimitedString) {
-        return delimitedString.split(this.delimiter).join('');
     }
 }
 

--- a/src/app/common/application/constants.ts
+++ b/src/app/common/application/constants.ts
@@ -108,7 +108,9 @@ export class Constants {
 
     public static readonly removablePrefixes: string[] = ['the', 'le', 'les', 'a', 'and'];
 
+    public static readonly unknownArtist: string = 'unknown-artist';
     public static readonly unknownGenre: string = 'unknown-genre';
+    public static readonly unknownTitle: string = 'unknown-title';
 
     public static readonly externalComponents: ExternalComponent[] = [
         new ExternalComponent(

--- a/src/app/common/application/constants.ts
+++ b/src/app/common/application/constants.ts
@@ -108,6 +108,8 @@ export class Constants {
 
     public static readonly removablePrefixes: string[] = ['the', 'le', 'les', 'a', 'and'];
 
+    public static readonly unknownGenre: string = 'unknown-genre';
+
     public static readonly externalComponents: ExternalComponent[] = [
         new ExternalComponent(
             'Angular',

--- a/src/app/common/sorting/artist-sorter.spec.ts
+++ b/src/app/common/sorting/artist-sorter.spec.ts
@@ -15,6 +15,8 @@ describe('ArtistSorter', () => {
     let artistModel8: ArtistModel;
     let artistModel9: ArtistModel;
     let artistModel10: ArtistModel;
+    let artistModel11: ArtistModel;
+    let artistModel12: ArtistModel;
 
     let translatorServiceMock: IMock<TranslatorServiceBase>;
     let loggerMock: IMock<Logger>;
@@ -36,6 +38,8 @@ describe('ArtistSorter', () => {
         artistModel8 = new ArtistModel('Artist8', translatorServiceMock.object);
         artistModel9 = new ArtistModel('Artist9', translatorServiceMock.object);
         artistModel10 = new ArtistModel('Artist10', translatorServiceMock.object);
+        artistModel11 = new ArtistModel('', translatorServiceMock.object);
+        artistModel12 = new ArtistModel('Артист', translatorServiceMock.object);
 
         artists = [
             artistModel2,
@@ -47,6 +51,8 @@ describe('ArtistSorter', () => {
             artistModel1,
             artistModel7,
             artistModel5,
+            artistModel11,
+            artistModel12,
             artistModel3,
         ];
 
@@ -81,16 +87,19 @@ describe('ArtistSorter', () => {
             const sortedArtists: ArtistModel[] = artistSorter.sortAscending(artists);
 
             // Assert
-            expect(sortedArtists[0]).toBe(artistModel1);
-            expect(sortedArtists[1]).toBe(artistModel2);
-            expect(sortedArtists[2]).toBe(artistModel3);
-            expect(sortedArtists[3]).toBe(artistModel4);
-            expect(sortedArtists[4]).toBe(artistModel5);
-            expect(sortedArtists[5]).toBe(artistModel6);
-            expect(sortedArtists[6]).toBe(artistModel7);
-            expect(sortedArtists[7]).toBe(artistModel8);
-            expect(sortedArtists[8]).toBe(artistModel9);
-            expect(sortedArtists[9]).toBe(artistModel10);
+            expect(sortedArtists.length).toEqual(12);
+            expect(sortedArtists[0]).toBe(artistModel11);
+            expect(sortedArtists[1]).toBe(artistModel12);
+            expect(sortedArtists[2]).toBe(artistModel1);
+            expect(sortedArtists[3]).toBe(artistModel2);
+            expect(sortedArtists[4]).toBe(artistModel3);
+            expect(sortedArtists[5]).toBe(artistModel4);
+            expect(sortedArtists[6]).toBe(artistModel5);
+            expect(sortedArtists[7]).toBe(artistModel6);
+            expect(sortedArtists[8]).toBe(artistModel7);
+            expect(sortedArtists[9]).toBe(artistModel8);
+            expect(sortedArtists[10]).toBe(artistModel9);
+            expect(sortedArtists[11]).toBe(artistModel10);
         });
     });
 
@@ -122,6 +131,7 @@ describe('ArtistSorter', () => {
             const sortedArtists: ArtistModel[] = artistSorter.sortDescending(artists);
 
             // Assert
+            expect(sortedArtists.length).toEqual(12);
             expect(sortedArtists[0]).toBe(artistModel10);
             expect(sortedArtists[1]).toBe(artistModel9);
             expect(sortedArtists[2]).toBe(artistModel8);
@@ -132,6 +142,8 @@ describe('ArtistSorter', () => {
             expect(sortedArtists[7]).toBe(artistModel3);
             expect(sortedArtists[8]).toBe(artistModel2);
             expect(sortedArtists[9]).toBe(artistModel1);
+            expect(sortedArtists[10]).toBe(artistModel12);
+            expect(sortedArtists[11]).toBe(artistModel11);
         });
     });
 });

--- a/src/app/common/sorting/genre-sorter.spec.ts
+++ b/src/app/common/sorting/genre-sorter.spec.ts
@@ -15,6 +15,8 @@ describe('GenreSorter', () => {
     let genreModel8: GenreModel;
     let genreModel9: GenreModel;
     let genreModel10: GenreModel;
+    let genreModel11: GenreModel;
+    let genreModel12: GenreModel;
 
     let translatorServiceMock: IMock<TranslatorServiceBase>;
     let loggerMock: IMock<Logger>;
@@ -36,6 +38,8 @@ describe('GenreSorter', () => {
         genreModel8 = new GenreModel('Genre8', translatorServiceMock.object);
         genreModel9 = new GenreModel('Genre9', translatorServiceMock.object);
         genreModel10 = new GenreModel('Genre10', translatorServiceMock.object);
+        genreModel11 = new GenreModel('', translatorServiceMock.object);
+        genreModel12 = new GenreModel('Жанр', translatorServiceMock.object);
 
         genres = [
             genreModel2,
@@ -47,6 +51,8 @@ describe('GenreSorter', () => {
             genreModel1,
             genreModel7,
             genreModel5,
+            genreModel11,
+            genreModel12,
             genreModel3,
         ];
 
@@ -81,16 +87,19 @@ describe('GenreSorter', () => {
             const sortedGenres: GenreModel[] = genreSorter.sortAscending(genres);
 
             // Assert
-            expect(sortedGenres[0]).toBe(genreModel1);
-            expect(sortedGenres[1]).toBe(genreModel2);
-            expect(sortedGenres[2]).toBe(genreModel3);
-            expect(sortedGenres[3]).toBe(genreModel4);
-            expect(sortedGenres[4]).toBe(genreModel5);
-            expect(sortedGenres[5]).toBe(genreModel6);
-            expect(sortedGenres[6]).toBe(genreModel7);
-            expect(sortedGenres[7]).toBe(genreModel8);
-            expect(sortedGenres[8]).toBe(genreModel9);
-            expect(sortedGenres[9]).toBe(genreModel10);
+            expect(sortedGenres.length).toEqual(12);
+            expect(sortedGenres[0]).toBe(genreModel11);
+            expect(sortedGenres[1]).toBe(genreModel12);
+            expect(sortedGenres[2]).toBe(genreModel1);
+            expect(sortedGenres[3]).toBe(genreModel2);
+            expect(sortedGenres[4]).toBe(genreModel3);
+            expect(sortedGenres[5]).toBe(genreModel4);
+            expect(sortedGenres[6]).toBe(genreModel5);
+            expect(sortedGenres[7]).toBe(genreModel6);
+            expect(sortedGenres[8]).toBe(genreModel7);
+            expect(sortedGenres[9]).toBe(genreModel8);
+            expect(sortedGenres[10]).toBe(genreModel9);
+            expect(sortedGenres[11]).toBe(genreModel10);
         });
     });
 
@@ -122,6 +131,7 @@ describe('GenreSorter', () => {
             const sortedGenres: GenreModel[] = genreSorter.sortDescending(genres);
 
             // Assert
+            expect(sortedGenres.length).toEqual(12);
             expect(sortedGenres[0]).toBe(genreModel10);
             expect(sortedGenres[1]).toBe(genreModel9);
             expect(sortedGenres[2]).toBe(genreModel8);
@@ -132,6 +142,8 @@ describe('GenreSorter', () => {
             expect(sortedGenres[7]).toBe(genreModel3);
             expect(sortedGenres[8]).toBe(genreModel2);
             expect(sortedGenres[9]).toBe(genreModel1);
+            expect(sortedGenres[10]).toBe(genreModel12);
+            expect(sortedGenres[11]).toBe(genreModel11);
         });
     });
 });

--- a/src/app/data/data-delimiter.spec.ts
+++ b/src/app/data/data-delimiter.spec.ts
@@ -92,7 +92,7 @@ describe('DataDelimiter', () => {
     });
 
     describe('fromDelimitedString', () => {
-        it('should return an empty collection if the delimited string is undefined', () => {
+        it('should return a collection with an empty string if the delimited string is undefined', () => {
             // Arrange
             const delimitedString: string | undefined = undefined;
 
@@ -100,10 +100,10 @@ describe('DataDelimiter', () => {
             const collection: string[] = DataDelimiter.fromDelimitedString(delimitedString);
 
             // Assert
-            expect(collection).toEqual([]);
+            expect(collection).toEqual(['']);
         });
 
-        it('should return an empty collection if the delimited string is empty', () => {
+        it('should return a collection with an empty string if the delimited string is empty', () => {
             // Arrange
             const delimitedString: string = '';
 
@@ -111,7 +111,7 @@ describe('DataDelimiter', () => {
             const collection: string[] = DataDelimiter.fromDelimitedString(delimitedString);
 
             // Assert
-            expect(collection).toEqual([]);
+            expect(collection).toEqual(['']);
         });
 
         it('should return a collection containing just the string if it does not have delimiters', () => {
@@ -156,6 +156,85 @@ describe('DataDelimiter', () => {
 
             // Assert
             expect(collection).toEqual(['the string 1', 'the string 2']);
+        });
+    });
+
+    describe('isUnknownValue', () => {
+        it('should return true when values is undefined', () => {
+            // Arrange
+            const values: string[] | undefined = undefined;
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it('should return true when values is empty', () => {
+            // Arrange
+            const values: string[] = [];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it('should return true when values contains one empty string', () => {
+            // Arrange
+            const values: string[] = [''];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it('should return true when values contains one blank string', () => {
+            // Arrange
+            const values: string[] = [' '];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it('should return false when values contains one non-empty string', () => {
+            // Arrange
+            const values: string[] = ['foo'];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false when values contains not only an empty string', () => {
+            // Arrange
+            const values: string[] = ['', 'foo'];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false when values contains more than one non-empty string', () => {
+            // Arrange
+            const values: string[] = ['foo', 'bar'];
+
+            // Act
+            const result: boolean = DataDelimiter.isUnknownValue(values);
+
+            // Assert
+            expect(result).toBeFalsy();
         });
     });
 });

--- a/src/app/data/data-delimiter.ts
+++ b/src/app/data/data-delimiter.ts
@@ -28,12 +28,16 @@ export class DataDelimiter {
 
     public static fromDelimitedString(delimitedString: string | undefined): string[] {
         if (StringUtils.isNullOrWhiteSpace(delimitedString)) {
-            return [];
+            return [''];
         }
 
         const delimitedStrings: string[] = delimitedString!.split(DataDelimiter.delimiter);
 
         return delimitedStrings.filter((x) => x !== '').map((x) => this.removeDelimiters(x));
+    }
+
+    public static isUnknownValue(values: string[] = []): boolean {
+        return values.length === 0 || (values.length === 1 && StringUtils.isNullOrWhiteSpace(values[0]));
     }
 
     private static addDelimiters(originalString: string): string {

--- a/src/app/services/album/album-model.ts
+++ b/src/app/services/album/album-model.ts
@@ -54,6 +54,10 @@ export class AlbumModel implements ISelectable {
     }
 
     public get genres(): string[] {
+        if (StringUtils.isNullOrWhiteSpace(this.albumData.genres)) {
+            return [this.translatorService.get(Constants.unknownGenre)];
+        }
+
         return DataDelimiter.fromDelimitedString(this.albumData.genres);
     }
 

--- a/src/app/services/album/album-model.ts
+++ b/src/app/services/album/album-model.ts
@@ -28,22 +28,22 @@ export class AlbumModel implements ISelectable {
     public get albumArtist(): string {
         const albumArtists = DataDelimiter.fromDelimitedString(this.albumData.albumArtists);
 
-        if (albumArtists != undefined && albumArtists.length > 0) {
+        if (!DataDelimiter.isUnknownValue(albumArtists)) {
             return albumArtists[0];
         }
 
         const trackArtists = DataDelimiter.fromDelimitedString(this.albumData.artists);
 
-        if (trackArtists != undefined && trackArtists.length > 0) {
+        if (!DataDelimiter.isUnknownValue(trackArtists)) {
             return trackArtists[0];
         }
 
-        return this.translatorService.get('unknown-artist');
+        return this.translatorService.get(Constants.unknownArtist);
     }
 
     public get albumTitle(): string {
         if (StringUtils.isNullOrWhiteSpace(this.albumData.albumTitle)) {
-            return this.translatorService.get('unknown-title');
+            return this.translatorService.get(Constants.unknownTitle);
         }
 
         return this.albumData.albumTitle!;
@@ -54,11 +54,13 @@ export class AlbumModel implements ISelectable {
     }
 
     public get genres(): string[] {
-        if (StringUtils.isNullOrWhiteSpace(this.albumData.genres)) {
+        const genres = DataDelimiter.fromDelimitedString(this.albumData.genres);
+
+        if (DataDelimiter.isUnknownValue(genres)) {
             return [this.translatorService.get(Constants.unknownGenre)];
         }
 
-        return DataDelimiter.fromDelimitedString(this.albumData.genres);
+        return genres;
     }
 
     public get albumKey(): string {

--- a/src/app/services/artist/artist-model.spec.ts
+++ b/src/app/services/artist/artist-model.spec.ts
@@ -9,7 +9,7 @@ describe('ArtistModel', () => {
     beforeEach(() => {
         translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
 
-        translatorServiceMock.setup((x) => x.get('Artist.UnknownArtist')).returns(() => 'Unknown artist');
+        translatorServiceMock.setup((x) => x.get('unknown-artist')).returns(() => 'Unknown artist');
         artistModel = new ArtistModel('My artist', translatorServiceMock.object);
     });
 

--- a/src/app/services/artist/artist-model.ts
+++ b/src/app/services/artist/artist-model.ts
@@ -2,6 +2,7 @@ import { SemanticZoomable } from '../../common/semantic-zoomable';
 import { StringUtils } from '../../common/utils/string-utils';
 import { ISelectable } from '../../ui/interfaces/i-selectable';
 import { TranslatorServiceBase } from '../translator/translator.service.base';
+import { Constants } from '../../common/application/constants';
 
 export class ArtistModel extends SemanticZoomable implements ISelectable {
     public constructor(
@@ -15,7 +16,7 @@ export class ArtistModel extends SemanticZoomable implements ISelectable {
 
     public get displayName(): string {
         if (StringUtils.isNullOrWhiteSpace(this.name)) {
-            return this.translatorService.get('Artist.UnknownArtist');
+            return this.translatorService.get(Constants.unknownArtist);
         }
 
         return this.name;

--- a/src/app/services/artist/artist-splitter.spec.ts
+++ b/src/app/services/artist/artist-splitter.spec.ts
@@ -26,7 +26,7 @@ describe('ArtistSplitter', () => {
 
     beforeEach(() => {
         translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
-        translatorServiceMock.setup((x) => x.get('Artist.UnknownArtist')).returns(() => 'Unknown artist');
+        translatorServiceMock.setup((x) => x.get('unknown-artist')).returns(() => 'Unknown artist');
 
         settingsMock = new SettingsMock();
     });

--- a/src/app/services/artist/artist.service.spec.ts
+++ b/src/app/services/artist/artist.service.spec.ts
@@ -1,4 +1,4 @@
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { ArtistModel } from './artist-model';
 import { ArtistType } from './artist-type';
 import { ArtistService } from './artist.service';
@@ -24,6 +24,8 @@ describe('ArtistService', () => {
         settingsMock = new SettingsMock();
         settingsMock.artistSplitSeparators = '';
         settingsMock.artistSplitExceptions = '';
+
+        translatorServiceMock.setup((x) => x.get('unknown-artist')).returns(() => 'Unknown artist');
     });
 
     function createService(): ArtistService {
@@ -63,6 +65,8 @@ describe('ArtistService', () => {
             trackArtistDatas.push(new ArtistData(';Metallica;;Madonna;'));
             trackArtistDatas.push(new ArtistData(';metallica;'));
             trackArtistDatas.push(new ArtistData(';Scorpions;'));
+            trackArtistDatas.push(new ArtistData(''));
+            trackArtistDatas.push(new ArtistData(''));
 
             const albumArtistDatas: ArtistData[] = [];
 
@@ -87,13 +91,30 @@ describe('ArtistService', () => {
             const artists: ArtistModel[] = service.getArtists(ArtistType.trackArtists);
 
             // Assert
-            expect(artists.length).toEqual(6);
+            expect(artists.length).toEqual(7);
+
+            expect(artists[0].name).toEqual('Aerosmith');
             expect(artists[0].displayName).toEqual('Aerosmith');
+
+            expect(artists[1].name).toEqual('Alanis Morissette');
             expect(artists[1].displayName).toEqual('Alanis Morissette');
+
+            expect(artists[2].name).toEqual('Bon Jovi');
             expect(artists[2].displayName).toEqual('Bon Jovi');
+
+            expect(artists[3].name).toEqual('Madonna');
             expect(artists[3].displayName).toEqual('Madonna');
+
+            expect(artists[4].name).toEqual('Metallica');
             expect(artists[4].displayName).toEqual('Metallica');
+
+            expect(artists[5].name).toEqual('Scorpions');
             expect(artists[5].displayName).toEqual('Scorpions');
+
+            expect(artists[6].name).toEqual('');
+            expect(artists[6].displayName).toEqual('Unknown artist');
+
+            translatorServiceMock.verify((x) => x.get('unknown-artist'), Times.once());
         });
 
         it('should get all album artists without duplicates when given ArtistType.albumArtists', () => {
@@ -126,6 +147,8 @@ describe('ArtistService', () => {
             albumArtistDatas.push(new ArtistData(';Rihanna;Jennifer Lopez;'));
             albumArtistDatas.push(new ArtistData(';Jennifer Lopez;'));
             albumArtistDatas.push(new ArtistData(';Madonna;;Jennifer Lopez;'));
+            albumArtistDatas.push(new ArtistData(''));
+            albumArtistDatas.push(new ArtistData(''));
 
             trackRepositoryMock.setup((x) => x.getTrackArtistData()).returns(() => trackArtistDatas);
             trackRepositoryMock.setup((x) => x.getAlbumArtistData()).returns(() => albumArtistDatas);
@@ -136,14 +159,33 @@ describe('ArtistService', () => {
             const artists: ArtistModel[] = service.getArtists(ArtistType.albumArtists);
 
             // Assert
-            expect(artists.length).toEqual(7);
+            expect(artists.length).toEqual(8);
+
+            expect(artists[0].name).toEqual('Aerosmith');
             expect(artists[0].displayName).toEqual('Aerosmith');
+
+            expect(artists[1].name).toEqual('Alanis Morissette');
             expect(artists[1].displayName).toEqual('Alanis Morissette');
+
+            expect(artists[2].name).toEqual('Bon Jovi');
             expect(artists[2].displayName).toEqual('Bon Jovi');
+
+            expect(artists[3].name).toEqual('Madonna');
             expect(artists[3].displayName).toEqual('Madonna');
+
+            expect(artists[4].name).toEqual('Megadeth');
             expect(artists[4].displayName).toEqual('Megadeth');
+
+            expect(artists[5].name).toEqual('Rihanna');
             expect(artists[5].displayName).toEqual('Rihanna');
+
+            expect(artists[6].name).toEqual('Jennifer Lopez');
             expect(artists[6].displayName).toEqual('Jennifer Lopez');
+
+            expect(artists[7].name).toEqual('');
+            expect(artists[7].displayName).toEqual('Unknown artist');
+
+            translatorServiceMock.verify((x) => x.get('unknown-artist'), Times.once());
         });
 
         it('should get all track and album artists without duplicates when given ArtistType.allArtists', () => {
@@ -162,6 +204,8 @@ describe('ArtistService', () => {
             trackArtistDatas.push(new ArtistData(';Metallica;;Madonna;'));
             trackArtistDatas.push(new ArtistData(';metallica;'));
             trackArtistDatas.push(new ArtistData(';Scorpions;'));
+            trackArtistDatas.push(new ArtistData(''));
+            trackArtistDatas.push(new ArtistData(''));
 
             const albumArtistDatas: ArtistData[] = [];
 
@@ -176,6 +220,8 @@ describe('ArtistService', () => {
             albumArtistDatas.push(new ArtistData(';Rihanna;Jennifer Lopez;'));
             albumArtistDatas.push(new ArtistData(';Jennifer Lopez;'));
             albumArtistDatas.push(new ArtistData(';Madonna;;Jennifer Lopez;'));
+            albumArtistDatas.push(new ArtistData(''));
+            albumArtistDatas.push(new ArtistData(''));
 
             trackRepositoryMock.setup((x) => x.getTrackArtistData()).returns(() => trackArtistDatas);
             trackRepositoryMock.setup((x) => x.getAlbumArtistData()).returns(() => albumArtistDatas);
@@ -186,16 +232,39 @@ describe('ArtistService', () => {
             const artists: ArtistModel[] = service.getArtists(ArtistType.allArtists);
 
             // Assert
-            expect(artists.length).toEqual(9);
+            expect(artists.length).toEqual(10);
+
+            expect(artists[0].name).toEqual('Aerosmith');
             expect(artists[0].displayName).toEqual('Aerosmith');
+
+            expect(artists[1].name).toEqual('Alanis Morissette');
             expect(artists[1].displayName).toEqual('Alanis Morissette');
+
+            expect(artists[2].name).toEqual('Bon Jovi');
             expect(artists[2].displayName).toEqual('Bon Jovi');
+
+            expect(artists[3].name).toEqual('Madonna');
             expect(artists[3].displayName).toEqual('Madonna');
+
+            expect(artists[4].name).toEqual('Metallica');
             expect(artists[4].displayName).toEqual('Metallica');
+
+            expect(artists[5].name).toEqual('Scorpions');
             expect(artists[5].displayName).toEqual('Scorpions');
-            expect(artists[6].displayName).toEqual('Megadeth');
-            expect(artists[7].displayName).toEqual('Rihanna');
-            expect(artists[8].displayName).toEqual('Jennifer Lopez');
+
+            expect(artists[6].name).toEqual('');
+            expect(artists[6].displayName).toEqual('Unknown artist');
+
+            expect(artists[7].name).toEqual('Megadeth');
+            expect(artists[7].displayName).toEqual('Megadeth');
+
+            expect(artists[8].name).toEqual('Rihanna');
+            expect(artists[8].displayName).toEqual('Rihanna');
+
+            expect(artists[9].name).toEqual('Jennifer Lopez');
+            expect(artists[9].displayName).toEqual('Jennifer Lopez');
+
+            translatorServiceMock.verify((x) => x.get('unknown-artist'), Times.once());
         });
     });
 

--- a/src/app/services/genre/genre-model.ts
+++ b/src/app/services/genre/genre-model.ts
@@ -2,6 +2,7 @@ import { SemanticZoomable } from '../../common/semantic-zoomable';
 import { StringUtils } from '../../common/utils/string-utils';
 import { ISelectable } from '../../ui/interfaces/i-selectable';
 import { TranslatorServiceBase } from '../translator/translator.service.base';
+import { Constants } from '../../common/application/constants';
 
 export class GenreModel extends SemanticZoomable implements ISelectable {
     public constructor(
@@ -15,7 +16,7 @@ export class GenreModel extends SemanticZoomable implements ISelectable {
 
     public get displayName(): string {
         if (StringUtils.isNullOrWhiteSpace(this.name)) {
-            return this.translatorService.get('unknown-genre');
+            return this.translatorService.get(Constants.unknownGenre);
         }
 
         return this.name;

--- a/src/app/services/genre/genre.service.spec.ts
+++ b/src/app/services/genre/genre.service.spec.ts
@@ -1,4 +1,4 @@
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { GenreModel } from './genre-model';
 import { GenreService } from './genre.service';
 import { TranslatorServiceBase } from '../translator/translator.service.base';
@@ -16,6 +16,8 @@ describe('GenreService', () => {
         translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
         trackRepositoryMock = Mock.ofType<TrackRepositoryBase>();
         loggerMock = Mock.ofType<Logger>();
+
+        translatorServiceMock.setup((x) => x.get('unknown-genre')).returns(() => 'Unknown genre');
 
         service = new GenreService(translatorServiceMock.object, trackRepositoryMock.object, loggerMock.object);
     });
@@ -59,6 +61,7 @@ describe('GenreService', () => {
             genreDatas.push(new GenreData(';Electro;;Dance;;Jazz;;Pop;;Rock;'));
             genreDatas.push(new GenreData(';Alternative;;Indie Rock;;Pop;;Rock;;Rock Pop;'));
             genreDatas.push(new GenreData(';Electro;;Techno;;House;'));
+            genreDatas.push(new GenreData(''));
 
             trackRepositoryMock.setup((x) => x.getGenreData()).returns(() => genreDatas);
 
@@ -66,23 +69,60 @@ describe('GenreService', () => {
             const genres: GenreModel[] = service.getGenres();
 
             // Assert
-            expect(genres.length).toEqual(16);
+            expect(genres.length).toEqual(17);
+
+            expect(genres[0].name).toEqual('Alternative');
             expect(genres[0].displayName).toEqual('Alternative');
+
+            expect(genres[1].name).toEqual('Rock');
             expect(genres[1].displayName).toEqual('Rock');
+
+            expect(genres[2].name).toEqual('Electro');
             expect(genres[2].displayName).toEqual('Electro');
+
+            expect(genres[3].name).toEqual('Dance');
             expect(genres[3].displayName).toEqual('Dance');
+
+            expect(genres[4].name).toEqual('Jazz');
             expect(genres[4].displayName).toEqual('Jazz');
+
+            expect(genres[5].name).toEqual('Indie Rock');
             expect(genres[5].displayName).toEqual('Indie Rock');
+
+            expect(genres[6].name).toEqual('Klassik');
             expect(genres[6].displayName).toEqual('Klassik');
+
+            expect(genres[7].name).toEqual('Indie');
             expect(genres[7].displayName).toEqual('Indie');
+
+            expect(genres[8].name).toEqual('Electronic');
             expect(genres[8].displayName).toEqual('Electronic');
+
+            expect(genres[9].name).toEqual('Indie Pop');
             expect(genres[9].displayName).toEqual('Indie Pop');
+
+            expect(genres[10].name).toEqual('Pop');
             expect(genres[10].displayName).toEqual('Pop');
+
+            expect(genres[11].name).toEqual('Folk');
             expect(genres[11].displayName).toEqual('Folk');
+
+            expect(genres[12].name).toEqual('Classical');
             expect(genres[12].displayName).toEqual('Classical');
+
+            expect(genres[13].name).toEqual('Rock Pop');
             expect(genres[13].displayName).toEqual('Rock Pop');
+
+            expect(genres[14].name).toEqual('Techno');
             expect(genres[14].displayName).toEqual('Techno');
+
+            expect(genres[15].name).toEqual('House');
             expect(genres[15].displayName).toEqual('House');
+
+            expect(genres[16].name).toEqual('');
+            expect(genres[16].displayName).toEqual('Unknown genre');
+
+            translatorServiceMock.verify((x) => x.get('unknown-genre'), Times.once());
         });
     });
 });

--- a/src/app/services/genre/genre.service.ts
+++ b/src/app/services/genre/genre.service.ts
@@ -27,10 +27,6 @@ export class GenreService implements GenreServiceBase {
         for (const genreData of genreDatas) {
             const genres: string[] = DataDelimiter.fromDelimitedString(genreData.genres);
 
-            if (genres.length === 0) {
-                genres.push('');
-            }
-
             for (const genre of genres) {
                 const processedGenre: string = genre.toLowerCase().trim();
 

--- a/src/app/services/genre/genre.service.ts
+++ b/src/app/services/genre/genre.service.ts
@@ -27,6 +27,10 @@ export class GenreService implements GenreServiceBase {
         for (const genreData of genreDatas) {
             const genres: string[] = DataDelimiter.fromDelimitedString(genreData.genres);
 
+            if (genres.length === 0) {
+                genres.push('');
+            }
+
             for (const genre of genres) {
                 const processedGenre: string = genre.toLowerCase().trim();
 

--- a/src/app/services/playback/playback.service.spec.ts
+++ b/src/app/services/playback/playback.service.spec.ts
@@ -950,14 +950,32 @@ describe('PlaybackService', () => {
             // Arrange
             const service: PlaybackService = createService();
 
-            const genreToPlay: GenreModel = new GenreModel('genre1', translatorServiceMock.object);
+            const genreName = 'genre1';
+            const genreToPlay: GenreModel = new GenreModel(genreName, translatorServiceMock.object);
             queueMock.setup((x) => x.getFirstTrack()).returns(() => trackModel1);
 
             // Act
             service.enqueueAndPlayGenre(genreToPlay);
 
             // Assert
-            trackServiceMock.verify((x) => x.getTracksForGenres([genreToPlay.displayName]), Times.exactly(1));
+            trackServiceMock.verify((x) => x.getTracksForGenres([genreName]), Times.once());
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
+        });
+
+        it('should get tracks for unknown genre', () => {
+            // Arrange
+            const service: PlaybackService = createService();
+
+            const genreName = '';
+            const genreToPlay: GenreModel = new GenreModel(genreName, translatorServiceMock.object);
+            queueMock.setup((x) => x.getFirstTrack()).returns(() => trackModel1);
+
+            // Act
+            service.enqueueAndPlayGenre(genreToPlay);
+
+            // Assert
+            trackServiceMock.verify((x) => x.getTracksForGenres([genreName]), Times.once());
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should order tracks for the artist byAlbum', () => {
@@ -2109,13 +2127,29 @@ describe('PlaybackService', () => {
         it('should get tracks for the given genre', async () => {
             // Arrange
             const service: PlaybackService = createService();
-            const genreToAdd: GenreModel = new GenreModel('genre1', translatorServiceMock.object);
+            const genreName = 'genre1';
+            const genreToAdd: GenreModel = new GenreModel(genreName, translatorServiceMock.object);
 
             // Act
             await service.addGenreToQueueAsync(genreToAdd);
 
             // Assert
-            trackServiceMock.verify((x) => x.getTracksForGenres([genreToAdd.displayName]), Times.exactly(1));
+            trackServiceMock.verify((x) => x.getTracksForGenres([genreName]), Times.once());
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
+        });
+
+        it('should get tracks for unknown genre', async () => {
+            // Arrange
+            const service: PlaybackService = createService();
+            const genreName = '';
+            const genreToAdd: GenreModel = new GenreModel(genreName, translatorServiceMock.object);
+
+            // Act
+            await service.addGenreToQueueAsync(genreToAdd);
+
+            // Assert
+            trackServiceMock.verify((x) => x.getTracksForGenres([genreName]), Times.once());
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should order tracks for the artist byAlbum', async () => {

--- a/src/app/services/playback/playback.service.ts
+++ b/src/app/services/playback/playback.service.ts
@@ -159,7 +159,7 @@ export class PlaybackService {
     }
 
     public enqueueAndPlayGenre(genreToPlay: GenreModel): void {
-        const tracksForGenre: TrackModels = this.trackService.getTracksForGenres([genreToPlay.displayName]);
+        const tracksForGenre: TrackModels = this.trackService.getTracksForGenres([genreToPlay.name]);
         const orderedTracks: TrackModel[] = this.trackSorter.sortByAlbum(tracksForGenre.tracks);
         this.enqueueAndPlayTracks(orderedTracks);
     }
@@ -195,7 +195,7 @@ export class PlaybackService {
             return;
         }
 
-        const tracksForGenre: TrackModels = this.trackService.getTracksForGenres([genreToAdd.displayName]);
+        const tracksForGenre: TrackModels = this.trackService.getTracksForGenres([genreToAdd.name]);
         const orderedTracks: TrackModel[] = this.trackSorter.sortByAlbum(tracksForGenre.tracks);
         await this.addTracksToQueueAsync(orderedTracks);
     }

--- a/src/app/services/track/track-model.ts
+++ b/src/app/services/track/track-model.ts
@@ -76,14 +76,14 @@ export class TrackModel implements ISelectable {
     public get artists(): string {
         const trackArtists: string[] = DataDelimiter.fromDelimitedString(this.track.artists);
 
-        if (trackArtists == undefined || trackArtists.length === 0) {
-            return this.translatorService.get('unknown-artist');
+        if (DataDelimiter.isUnknownValue(trackArtists)) {
+            return this.translatorService.get(Constants.unknownArtist);
         }
 
         const commaSeparatedArtists: string = CollectionUtils.toCommaSeparatedString(trackArtists);
 
         if (commaSeparatedArtists.length === 0) {
-            return this.translatorService.get('unknown-artist');
+            return this.translatorService.get(Constants.unknownArtist);
         }
 
         return commaSeparatedArtists;
@@ -92,7 +92,7 @@ export class TrackModel implements ISelectable {
     public get rawArtists(): string[] {
         const trackArtists: string[] = DataDelimiter.fromDelimitedString(this.track.artists);
 
-        if (trackArtists == undefined) {
+        if (DataDelimiter.isUnknownValue(trackArtists)) {
             return [];
         }
 
@@ -116,7 +116,7 @@ export class TrackModel implements ISelectable {
     public get genres(): string {
         const trackGenres: string[] = DataDelimiter.fromDelimitedString(this.track.genres);
 
-        if (trackGenres == undefined || trackGenres.length === 0) {
+        if (DataDelimiter.isUnknownValue(trackGenres)) {
             return this.translatorService.get(Constants.unknownGenre);
         }
 
@@ -164,17 +164,17 @@ export class TrackModel implements ISelectable {
     public get albumArtists(): string {
         const albumArtists: string[] = DataDelimiter.fromDelimitedString(this.track.albumArtists);
 
-        if (albumArtists != undefined && albumArtists.length > 0) {
+        if (!DataDelimiter.isUnknownValue(albumArtists)) {
             return albumArtists.join(', ');
         }
 
         const trackArtists: string[] = DataDelimiter.fromDelimitedString(this.track.artists);
 
-        if (trackArtists != undefined && trackArtists.length > 0) {
+        if (!DataDelimiter.isUnknownValue(trackArtists)) {
             return trackArtists.join(', ');
         }
 
-        return this.translatorService.get('unknown-artist');
+        return this.translatorService.get(Constants.unknownArtist);
     }
 
     public get sortableAlbumArtists(): string {

--- a/src/app/services/track/track-model.ts
+++ b/src/app/services/track/track-model.ts
@@ -5,6 +5,7 @@ import { StringUtils } from '../../common/utils/string-utils';
 import { TranslatorServiceBase } from '../translator/translator.service.base';
 import { ISelectable } from '../../ui/interfaces/i-selectable';
 import { CollectionUtils } from '../../common/utils/collections-utils';
+import { Constants } from '../../common/application/constants';
 
 export class TrackModel implements ISelectable {
     public constructor(
@@ -116,13 +117,13 @@ export class TrackModel implements ISelectable {
         const trackGenres: string[] = DataDelimiter.fromDelimitedString(this.track.genres);
 
         if (trackGenres == undefined || trackGenres.length === 0) {
-            return this.translatorService.get('unknown-genre');
+            return this.translatorService.get(Constants.unknownGenre);
         }
 
         const commaSeparatedGenres: string = CollectionUtils.toCommaSeparatedString(trackGenres);
 
         if (commaSeparatedGenres.length === 0) {
-            return this.translatorService.get('unknown-genre');
+            return this.translatorService.get(Constants.unknownGenre);
         }
 
         return commaSeparatedGenres;

--- a/src/app/ui/components/collection/collection-genres/collection-genres.component.spec.ts
+++ b/src/app/ui/components/collection/collection-genres/collection-genres.component.spec.ts
@@ -16,7 +16,6 @@ import { Scheduler } from '../../../../common/scheduling/scheduler';
 import { Logger } from '../../../../common/logger';
 import { DateTime } from '../../../../common/date-time';
 import { TranslatorServiceBase } from '../../../../services/translator/translator.service.base';
-import { FileAccess } from '../../../../common/io/file-access';
 import { GenreModel } from '../../../../services/genre/genre-model';
 import { AlbumModel } from '../../../../services/album/album-model';
 import { AlbumData } from '../../../../data/entities/album-data';
@@ -42,7 +41,6 @@ describe('CollectionGenresComponent', () => {
 
     let dateTimeMock: IMock<DateTime>;
     let translatorServiceMock: IMock<TranslatorServiceBase>;
-    let fileAccessMock: IMock<FileAccess>;
 
     let selectedGenresChangedMock: Subject<string[]>;
     let selectedGenresChangedMock$: Observable<string[]>;
@@ -115,7 +113,6 @@ describe('CollectionGenresComponent', () => {
         loggerMock = Mock.ofType<Logger>();
         dateTimeMock = Mock.ofType<DateTime>();
         translatorServiceMock = Mock.ofType<TranslatorServiceBase>();
-        fileAccessMock = Mock.ofType<FileAccess>();
         applicationPathsMock = Mock.ofType<ApplicationPaths>();
 
         selectedGenresChangedMock = new Subject();

--- a/src/app/ui/components/collection/collection-genres/collection-genres.component.ts
+++ b/src/app/ui/components/collection/collection-genres/collection-genres.component.ts
@@ -131,7 +131,7 @@ export class CollectionGenresComponent implements OnInit, OnDestroy {
 
     private getAlbums(): void {
         const selectedGenres: GenreModel[] = this.genresPersister.getSelectedGenres(this.genres);
-        this.getAlbumsForGenres(selectedGenres.map((x) => x.displayName));
+        this.getAlbumsForGenres(selectedGenres.map((x) => x.name));
     }
 
     private getTracks(): void {
@@ -141,7 +141,7 @@ export class CollectionGenresComponent implements OnInit, OnDestroy {
             this.getTracksForAlbumKeys(selectedAlbums.map((x) => x.albumKey));
         } else {
             const selectedGenres: GenreModel[] = this.genresPersister.getSelectedGenres(this.genres);
-            this.getTracksForGenres(selectedGenres.map((x) => x.displayName));
+            this.getTracksForGenres(selectedGenres.map((x) => x.name));
         }
     }
 

--- a/src/app/ui/components/collection/collection-genres/genres-persister.spec.ts
+++ b/src/app/ui/components/collection/collection-genres/genres-persister.spec.ts
@@ -1,5 +1,5 @@
 import { Subscription } from 'rxjs';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { GenreOrder } from './genre-browser/genre-order';
 import { GenresPersister } from './genres-persister';
 import { TranslatorServiceBase } from '../../../../services/translator/translator.service.base';
@@ -29,7 +29,7 @@ describe('GenresPersister', () => {
 
         genre1 = new GenreModel('genre 1', translatorServiceMock.object);
         genre2 = new GenreModel('genre 2', translatorServiceMock.object);
-        genre3 = new GenreModel('genre 3', translatorServiceMock.object);
+        genre3 = new GenreModel('', translatorServiceMock.object);
     });
 
     describe('constructor', () => {
@@ -51,8 +51,9 @@ describe('GenresPersister', () => {
             // Act
 
             // Assert
-            expect(persister.getSelectedGenres([genre1, genre2])).toEqual([genre1]);
+            expect(persister.getSelectedGenres([genre1, genre2, genre3])).toEqual([genre1]);
             expect(persister.getSelectedGenreOrder()).toEqual(GenreOrder.byGenreDescending);
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
     });
 
@@ -92,6 +93,7 @@ describe('GenresPersister', () => {
 
             // Assert
             expect(selectedGenres).toEqual([]);
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should return the selected genres if the selected genres are found in availableGenres', () => {
@@ -105,19 +107,21 @@ describe('GenresPersister', () => {
 
             // Assert
             expect(selectedGenres).toEqual([genre1, genre2]);
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
     });
 
     describe('setSelectedGenres', () => {
         it('should clear the selected genres if selectedGenres is undefined', () => {
             // Arrange
-            persister.setSelectedGenres([genre1, genre2]);
+            persister.setSelectedGenres([genre1, genre2, genre3]);
 
             // Act
             persister.setSelectedGenres(undefined);
 
             // Assert
-            expect(persister.getSelectedGenres([genre1, genre2])).toEqual([]);
+            expect(persister.getSelectedGenres([genre1, genre2, genre3])).toEqual([]);
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should clear the selected genres if selectedGenres is empty', () => {
@@ -131,6 +135,7 @@ describe('GenresPersister', () => {
             // Assert
             expect(persister.getSelectedGenres([genre1, genre2])).toEqual([]);
             expect(settingsStub.genresTabSelectedGenre).toEqual('');
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should set the selected genres if selectedGenres has elements', () => {
@@ -143,6 +148,7 @@ describe('GenresPersister', () => {
             // Assert
             expect(persister.getSelectedGenres([genre3])).toEqual([genre3]);
             expect(settingsStub.genresTabSelectedGenre).toEqual('genre 1');
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
 
         it('should notify that the selected genres have changed', () => {
@@ -161,8 +167,9 @@ describe('GenresPersister', () => {
             // Assert
             expect(receivedGenreNames.length).toEqual(2);
             expect(receivedGenreNames[0]).toEqual('genre 1');
-            expect(receivedGenreNames[1]).toEqual('genre 3');
+            expect(receivedGenreNames[1]).toEqual('');
             subscription.unsubscribe();
+            translatorServiceMock.verify((x) => x.get(It.isAny()), Times.never());
         });
     });
 

--- a/src/app/ui/components/collection/collection-genres/genres-persister.ts
+++ b/src/app/ui/components/collection/collection-genres/genres-persister.ts
@@ -31,7 +31,7 @@ export class GenresPersister {
         }
 
         try {
-            return availableGenres.filter((x) => this.selectedGenreNames.includes(x.displayName));
+            return availableGenres.filter((x) => this.selectedGenreNames.includes(x.name));
         } catch (e: unknown) {
             this.logger.error(e, 'Could not get selected genres', 'GenresPersister', 'getSelectedGenres');
         }
@@ -42,7 +42,7 @@ export class GenresPersister {
     public setSelectedGenres(selectedGenres: GenreModel[] | undefined): void {
         try {
             if (selectedGenres != undefined && selectedGenres.length > 0) {
-                this.selectedGenreNames = selectedGenres.map((x) => x.displayName);
+                this.selectedGenreNames = selectedGenres.map((x) => x.name);
             } else {
                 this.selectedGenreNames = [];
             }


### PR DESCRIPTION
I'm not sure whether it's by design or not, but `unknown genre` is not exposed in `genres browser`.

**Unknown genre:**
- is empty in the db and in `GenreModel.name` which is used on the BE
- is translated in `GenreModel.displayName` ,  `TrackModel.genres` and `AlbumModel.genres` which is used on the FE

I believe something similar should be considered for `unknown artist`.