### PR TITLE
Exclude unnecessary files from asar bundle

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -55,7 +55,17 @@ const config = {
     directories: {
         output: 'release',
     },
-    files: ['**/*'],
+    files: [
+        'dist/',
+        'main/',
+        'static/',
+        'main.js',
+        'package.json',
+        '!main/background-work/mocks',
+        '!**/*.map',
+        '!**/*.ts',
+        '!**/*.spec.*',
+    ],
     extraResources: ['LICENSE'],
     win: {
         target: ['nsis'],


### PR DESCRIPTION
I suddenly realized that my local Dopamine build weights ~11GB. The reason is that `asar` bundle includes literally all files which is unnecessary, so I tried to optimize it. The configuration works, but I don't use all features, so please verify that all needed files are included.

<details>
<summary>Unpacked asar before</summary>

<img width="257" height="754" alt="asar-content-before" src="https://github.com/user-attachments/assets/30fdacc1-5b11-4f1b-8d4e-2cd51bd0fdca" />

</details>

<details>
<summary>Unpacked asar after</summary>

<img width="183" height="165" alt="asar-content-after" src="https://github.com/user-attachments/assets/05d6b3c2-e87d-4b6f-85b2-a189d19f3179" />

</details>