### PR TITLE
Fix app-playback-cover-art styling

### DIFF
--- a/src/app/ui/components/collection/collection-playback-pane/collection-playback-pane.component.html
+++ b/src/app/ui/components/collection/collection-playback-pane/collection-playback-pane.component.html
@@ -3,7 +3,7 @@
     <div class="app-collection-playback-pane__controls">
         <div class="app-collection-playback-pane-controls__left">
             <app-playback-cover-art
-                class="app-collection-playback-pane__cover pointer"
+                extraTopClasses="app-collection-playback-pane__cover pointer"
                 [size]="59"
                 [borderRadius]="4"
                 (click)="this.showNowPlayingAsync()"

--- a/src/app/ui/components/mini-players/cover-player/cover-player.component.html
+++ b/src/app/ui/components/mini-players/cover-player/cover-player.component.html
@@ -11,7 +11,7 @@
 </div>
 <div class="cover-player__content">
     <div class="cover-player__cover-pane">
-        <app-playback-cover-art class="cover-player-cover-pane__cover" [size]="350"></app-playback-cover-art>
+        <app-playback-cover-art extraTopClasses="cover-player-cover-pane__cover" [size]="350"></app-playback-cover-art>
         <div class="cover-player-cover-pane__songinfo" [@controlsVisibility]="controlsVisibility">
             <app-playback-information
                 class="mx-4"

--- a/src/app/ui/components/now-playing/now-playing-lyrics/now-playing-lyrics.component.html
+++ b/src/app/ui/components/now-playing/now-playing-lyrics/now-playing-lyrics.component.html
@@ -1,6 +1,10 @@
 <div class="app-now-playing-lyrics">
     <div class="d-flex flex-column">
-        <app-playback-cover-art class="app-now-playing-lyrics__picture" [size]="300" [borderRadius]="10"></app-playback-cover-art>
+        <app-playback-cover-art
+            extraTopClasses="app-now-playing-lyrics__picture"
+            [size]="300"
+            [borderRadius]="10">
+        </app-playback-cover-art>
         <div class="mt-3 mx-1">
             <div class="secondary-text d-flex align-items-center" *ngIf="this.lyrics?.sourceType === lyricsSourceTypeEnum.none">
                 {{ 'no-lyrics' | translate }}<i class="secondary-text las la-frown ml-1"></i>

--- a/src/app/ui/components/now-playing/now-playing-showcase/now-playing-showcase.component.html
+++ b/src/app/ui/components/now-playing/now-playing-showcase/now-playing-showcase.component.html
@@ -1,8 +1,10 @@
 <div class="app-now-playing-showcase">
     <div class="app-now-playing-showcase__song">
-        <div class="app-now-playing-showcase__cover">
-            <app-playback-cover-art [size]="coverArtSize" [borderRadius]="10"></app-playback-cover-art>
-        </div>
+        <app-playback-cover-art
+            extraTopClasses="app-now-playing-showcase__cover"
+            [size]="coverArtSize"
+            [borderRadius]="10">
+        </app-playback-cover-art>
 
         <div class="app-now-playing-showcase__songinfo" [style.height.px]="coverArtSize">
             <app-playback-information

--- a/src/app/ui/components/playback-cover-art/playback-cover-art.component.html
+++ b/src/app/ui/components/playback-cover-art/playback-cover-art.component.html
@@ -1,19 +1,17 @@
-<div class="app-playback-cover-art" [style.width.px]="size" [style.height.px]="size" [style.border-radius.px]="borderRadius">
-    <div class="app-playback-cover-art__logo" [style.width.px]="size" [style.height.px]="size">
+<div [ngClass]="this.topClasses" [style.width.px]="size" [style.height.px]="size" [style.border-radius.px]="borderRadius">
+    <div class="app-playback-cover-art__logo">
         <svg width="256" height="256" viewBox="0 0 256 256">
             <path
                 d="M 208.79492 0 L 208.79492 85.669922 A 104.26329 104.26329 0 0 0 128.05273 47.373047 A 104.26329 104.26329 0 0 0 23.789062 151.63672 A 104.26329 104.26329 0 0 0 128.05273 255.90039 A 104.26329 104.26329 0 0 0 232.31641 151.63672 A 104.26329 104.26329 0 0 0 232.30859 150.50391 L 232.31055 150.50391 L 232.31055 0 L 208.79492 0 z M 128.05273 71.195312 A 80.750832 80.441704 0 0 1 208.79492 150.50391 A 80.750832 80.441704 0 0 1 208.80273 151.63672 A 80.750832 80.441704 0 0 1 128.05273 232.07812 A 80.750832 80.441704 0 0 1 47.302734 151.63672 A 80.750832 80.441704 0 0 1 128.05273 71.195312 z M 127.9707 134.98047 A 16.65657 16.65657 0 0 0 111.39648 151.63672 A 16.65657 16.65657 0 0 0 128.05273 168.29297 A 16.65657 16.65657 0 0 0 144.70898 151.63672 A 16.65657 16.65657 0 0 0 128.05273 134.98047 A 16.65657 16.65657 0 0 0 127.9707 134.98047 z "
             />
         </svg>
     </div>
-    <div class="app-playback-cover-art__content" [style.width.px]="size" [style.height.px]="size">
+    <div class="app-playback-cover-art__content">
         <div [@contentAnimation]="contentAnimation" [style.min-width.px]="size" [style.min-height.px]="size">
             <img
                 *ngIf="topImageUrl"
                 [ngClass]="this.topImageBackgroundClass"
                 [src]="this.topImageUrl"
-                [width]="size"
-                [height]="size"
                 draggable="false"
             />
         </div>
@@ -22,8 +20,6 @@
                 *ngIf="bottomImageUrl"
                 [ngClass]="this.bottomImageBackgroundClass"
                 [src]="this.bottomImageUrl"
-                [width]="size"
-                [height]="size"
                 draggable="false"
             />
         </div>

--- a/src/app/ui/components/playback-cover-art/playback-cover-art.component.scss
+++ b/src/app/ui/components/playback-cover-art/playback-cover-art.component.scss
@@ -5,6 +5,11 @@
     grid-template-columns: 1fr;
 }
 
+.app-playback-cover-art * {
+    width: inherit;
+    height: inherit;
+}
+
 .app-playback-cover-art div {
     grid-row-start: 1;
     grid-column-start: 1;

--- a/src/app/ui/components/playback-cover-art/playback-cover-art.component.spec.ts
+++ b/src/app/ui/components/playback-cover-art/playback-cover-art.component.spec.ts
@@ -108,6 +108,14 @@ describe('PlaybackCoverArtComponent', () => {
             // Assert
             expect(component.size).toEqual(0);
         });
+
+        it('should initialize extraTopClasses as empty', () => {
+            // Arrange, Act
+            const component: PlaybackCoverArtComponent = createComponent();
+
+            // Assert
+            expect(component.extraTopClasses).toEqual('');
+        });
     });
 
     describe('ngOnInit', () => {
@@ -246,6 +254,26 @@ describe('PlaybackCoverArtComponent', () => {
 
             // Act, Assert
             expect(component.bottomImageBackgroundClass).toEqual('');
+        });
+    });
+
+    describe('topClasses', () => {
+        it('should return "app-playback-cover-art" when extraTopClasses is empty', async () => {
+            // Arrange
+            const component: PlaybackCoverArtComponent = createComponent();
+            component.extraTopClasses = '';
+
+            // Act, Assert
+            expect(component.topClasses).toEqual('app-playback-cover-art');
+        });
+
+        it('should return "app-playback-cover-art" plus extraTopClasses when extraTopClasses is not empty', async () => {
+            // Arrange
+            const component: PlaybackCoverArtComponent = createComponent();
+            component.extraTopClasses = "foo bar";
+
+            // Act, Assert
+            expect(component.topClasses).toEqual('app-playback-cover-art foo bar');
         });
     });
 });

--- a/src/app/ui/components/playback-cover-art/playback-cover-art.component.ts
+++ b/src/app/ui/components/playback-cover-art/playback-cover-art.component.ts
@@ -7,6 +7,7 @@ import { SchedulerBase } from '../../../common/scheduling/scheduler.base';
 import { Constants } from '../../../common/application/constants';
 import { PlaybackInformationService } from '../../../services/playback-information/playback-information.service';
 import { IndexingService } from '../../../services/indexing/indexing.service';
+import { StringUtils } from '../../../common/utils/string-utils';
 
 @Component({
     selector: 'app-playback-cover-art',
@@ -46,6 +47,7 @@ import { IndexingService } from '../../../services/indexing/indexing.service';
     ],
 })
 export class PlaybackCoverArtComponent implements OnInit, OnDestroy {
+    private readonly defaultTopClasses: string = 'app-playback-cover-art';
     private subscription: Subscription = new Subscription();
     private currentImageUrl: string = '';
 
@@ -62,6 +64,9 @@ export class PlaybackCoverArtComponent implements OnInit, OnDestroy {
 
     @Input()
     public borderRadius: number = 0;
+
+    @Input()
+    public extraTopClasses: string = '';
 
     public topImageUrl: string = '';
     public bottomImageUrl: string = '';
@@ -80,6 +85,14 @@ export class PlaybackCoverArtComponent implements OnInit, OnDestroy {
         }
 
         return '';
+    }
+
+    public get topClasses(): string {
+        if (StringUtils.isNullOrWhiteSpace(this.extraTopClasses)) {
+            return this.defaultTopClasses;
+        }
+
+        return `${this.defaultTopClasses} ${this.extraTopClasses}`;
     }
 
     public ngOnDestroy(): void {


### PR DESCRIPTION
- `app-playback-cover-art` must configure top classes together to apply border radius consistently and to avoid unnecessary outside wrappers
- fixed (img didn't take the whole space) and simplified `playback-cover-art.component.html` width and height via css

<details>
<summary>Before</summary>

<img width="1920" height="1050" alt="lyrics-before" src="https://github.com/user-attachments/assets/230dba91-c242-4dcc-bc6e-35f05ab6e3a0" />
<img width="1920" height="1050" alt="lyrics-logo-before" src="https://github.com/user-attachments/assets/a3822870-606a-4f63-969f-fca5d62d90d5" />
<img width="350" height="430" alt="mini-player-before" src="https://github.com/user-attachments/assets/0598c4a1-bdbe-4da1-bcc4-08833516c45b" />
<img width="350" height="430" alt="mini-player-logo-before" src="https://github.com/user-attachments/assets/cf70bbce-443d-4d69-87d3-0b359e3924aa" />
<img width="1920" height="1050" alt="showcase-before" src="https://github.com/user-attachments/assets/415e3f50-458e-4b48-94c3-bc8f97b36139" />
<img width="1920" height="1050" alt="showcase-logo-before" src="https://github.com/user-attachments/assets/2c874506-a591-430e-9dca-6d0cce58e1ea" />


</details>

<details>
<summary>After</summary>

<img width="1920" height="1050" alt="lyrics-after" src="https://github.com/user-attachments/assets/11732608-8fd3-4cf8-b43b-e922c2bc4894" />
<img width="1920" height="1050" alt="lyrics-logo-after" src="https://github.com/user-attachments/assets/91859694-9107-4fb5-a1d3-c504301f2b2a" />
<img width="350" height="430" alt="mini-player-after" src="https://github.com/user-attachments/assets/ff33c7aa-c5b6-4c4e-8789-cc5830d18018" />
<img width="350" height="430" alt="mini-player-logo-after" src="https://github.com/user-attachments/assets/3ea4fdd2-42bd-4af0-a66e-89b3f52f74b4" />
<img width="1920" height="1050" alt="showcase-after" src="https://github.com/user-attachments/assets/72807d83-bf33-4c4f-b945-58b71ad62faa" />
<img width="1920" height="1050" alt="showcase-logo-after" src="https://github.com/user-attachments/assets/7a06b42c-f33d-4f06-aa9b-a7253946f2c3" />


</details>