### PR TITLE
Fix Support for m3u8 Playlist Files

### DIFF
--- a/src/app/common/application/file-formats.ts
+++ b/src/app/common/application/file-formats.ts
@@ -22,7 +22,7 @@ export class FileFormats {
     public static readonly m3u: string = '.m3u';
     public static readonly m3u8: string = '.m3u8';
 
-    public static readonly supportedPlaylistExtensions: string[] = [FileFormats.m3u, FileFormats.flac];
+    public static readonly supportedPlaylistExtensions: string[] = [FileFormats.m3u, FileFormats.m3u8];
 
     // Playlist image extensions
     public static readonly png: string = '.png';


### PR DESCRIPTION
It appears the readonly array `supportedPlaylistExtensions` was intended to have `m3u` and `m3u8` (not `flac`). From what I can tell this array is used in the validation step for reading playlists in the Dopamine playlist folder. I came to this conclusion when I stumbled upon this line of code:
https://github.com/digimezzo/dopamine/blob/0328c3af30f6966cb1feaea86a2a49b5871a1eeb/src/app/services/playlist/playlist-decoder.ts#L14-L19
Which is attempting to parse playlist files and accepts both the `m3u` and `m3u8` extensions. It appears Dopamine supports UTF-8 encodings fine so I don't see why it would explicitly restrict `m3u8` files in the validation step, but please enlighten me if I am wrong.

Without this change, Dopamine does not recognize `m3u8` playlist files when placed in the playlist folder. I tested this change using Windows 11, node 20.19.5, npm 11.6.2 and confirmed the playlist appeared and played music from an `m3u8` playlist file.

|Before Changes|After Changes|
|---|---|
|<img width="1471" height="801" alt="Playlistm3u8Bug" src="https://github.com/user-attachments/assets/b0d6fa6e-900e-4dae-a2f5-7d482e27a90b" />|<img width="1462" height="877" alt="Playlistm3u8BugFixed" src="https://github.com/user-attachments/assets/d806761d-298e-4465-a80c-d156c255b7da" />|

See https://github.com/digimezzo/dopamine/issues/907