### PR TITLE
Async track fetching when selecting playlist.

### DIFF
--- a/src/app/common/io/file-access.base.ts
+++ b/src/app/common/io/file-access.base.ts
@@ -10,6 +10,7 @@ export abstract class FileAccessBase {
     public abstract getDateModifiedInTicks(fileOrDirectory: string): number;
     public abstract getDateCreatedInTicks(fileOrDirectory: string): number;
     public abstract pathExists(pathToCheck: string): boolean;
+    public abstract pathExistsAsync(pathToCheck: string): Promise<boolean>;
     public abstract getFileSizeInBytes(filePath: string): number;
     public abstract createFullDirectoryPathIfDoesNotExist(directoryPath: string): void;
     public abstract createFile(filePath: string): void;

--- a/src/app/common/io/file-access.ts
+++ b/src/app/common/io/file-access.ts
@@ -145,6 +145,15 @@ export class FileAccess implements FileAccessBase {
         return fs.existsSync(pathToCheck);
     }
 
+    public async pathExistsAsync(pathToCheck: string): Promise<boolean> {
+        try {
+            await fs.promises.access(pathToCheck, fs.promises.constants.F_OK);
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
     public getFileSizeInBytes(filePath: string): number {
         const stats = fs.statSync(filePath);
         return stats.size;

--- a/src/app/common/validation/file-validator.ts
+++ b/src/app/common/validation/file-validator.ts
@@ -1,10 +1,29 @@
 import { Injectable } from '@angular/core';
 import { FileFormats } from '../application/file-formats';
 import { FileAccessBase } from '../io/file-access.base';
+import { access, constants } from 'fs';
 
 @Injectable()
 export class FileValidator {
     public constructor(private fileAccess: FileAccessBase) {}
+
+    public async isPlayableAudioFileAsync(filePath: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            access(filePath, constants.F_OK, (err) => {
+                if (err) {
+                    resolve(false);
+                }
+
+                const fileExtension: string = this.fileAccess.getFileExtension(filePath);
+
+                if (!FileFormats.supportedAudioExtensions.includes(fileExtension.toLowerCase())) {
+                    resolve(false);
+                }
+
+                resolve(true);
+            });
+        });
+    }
 
     public isPlayableAudioFile(filePath: string): boolean {
         if (!this.fileAccess.pathExists(filePath)) {

--- a/src/app/common/validation/file-validator.ts
+++ b/src/app/common/validation/file-validator.ts
@@ -1,28 +1,23 @@
 import { Injectable } from '@angular/core';
 import { FileFormats } from '../application/file-formats';
 import { FileAccessBase } from '../io/file-access.base';
-import { access, constants } from 'fs';
 
 @Injectable()
 export class FileValidator {
     public constructor(private fileAccess: FileAccessBase) {}
 
     public async isPlayableAudioFileAsync(filePath: string): Promise<boolean> {
-        return new Promise((resolve) => {
-            access(filePath, constants.F_OK, (err) => {
-                if (err) {
-                    resolve(false);
-                }
+        if (!await this.fileAccess.pathExistsAsync(filePath)) {
+            return false;
+        }
 
-                const fileExtension: string = this.fileAccess.getFileExtension(filePath);
+        const fileExtension: string = this.fileAccess.getFileExtension(filePath);
 
-                if (!FileFormats.supportedAudioExtensions.includes(fileExtension.toLowerCase())) {
-                    resolve(false);
-                }
+        if (!FileFormats.supportedAudioExtensions.includes(fileExtension.toLowerCase())) {
+            return false;
+        }
 
-                resolve(true);
-            });
-        });
+        return true;
     }
 
     public isPlayableAudioFile(filePath: string): boolean {

--- a/src/app/services/playlist/playlist.service.ts
+++ b/src/app/services/playlist/playlist.service.ts
@@ -24,7 +24,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { Constants } from '../../common/application/constants';
 import { PlaylistUpdateInfo } from './playlist-update-info';
 import { PromiseUtils } from '../../common/utils/promise-utils';
-import {SettingsBase} from "../../common/settings/settings.base";
+import { SettingsBase } from '../../common/settings/settings.base';
 
 @Injectable()
 export class PlaylistService implements PlaylistServiceBase {
@@ -284,14 +284,13 @@ export class PlaylistService implements PlaylistServiceBase {
             throw new Error(e instanceof Error ? e.message : 'Unknown error');
         }
 
-        
         const albumKeyIndex = this.settings.albumKeyIndex;
 
         for (const playlistEntry of playlistEntries) {
             if (await this.fileValidator.isPlayableAudioFileAsync(playlistEntry.decodedPath)) {
                 const track: TrackModel = await this.trackModelFactory.createFromFileAsync(playlistEntry.decodedPath, albumKeyIndex);
                 tracks.push(track);
-            } 
+            }
         }
 
         return tracks;

--- a/src/app/services/playlist/playlist.service.ts
+++ b/src/app/services/playlist/playlist.service.ts
@@ -283,15 +283,15 @@ export class PlaylistService implements PlaylistServiceBase {
             this.logger.error(e, `Could not decode playlist with path='${playlistPath}'`, 'PlaylistService', 'decodePlaylistAsync');
             throw new Error(e instanceof Error ? e.message : 'Unknown error');
         }
-        
+
         
         const albumKeyIndex = this.settings.albumKeyIndex;
 
         for (const playlistEntry of playlistEntries) {
-            if (this.fileValidator.isPlayableAudioFile(playlistEntry.decodedPath)) {
+            if (await this.fileValidator.isPlayableAudioFileAsync(playlistEntry.decodedPath)) {
                 const track: TrackModel = await this.trackModelFactory.createFromFileAsync(playlistEntry.decodedPath, albumKeyIndex);
                 tracks.push(track);
-            }
+            } 
         }
 
         return tracks;


### PR DESCRIPTION
This fixes Dopamine freezing when selecting a playlist with many tracks, or with tracks in a location which takes a significant time to read. For example, if a file from the playlist is in an unavailable network drive, Dopamine completely freezes for approximately 2.5s.

The cause of the freezing is `fs.existsSync()` via `PlaylistService.getTracksAsync()` -> `PlaylistService.decodePlaylistAsync()` -> `FileValidator.isPlayableAudioFile()`. 

Fix uses async method `fs.access()` instead of the blocking `fs.existsSync()`.

Note that this also means that other functions reliant on `FileValidator.isPlayableAudioFile()` will also freeze Dopamine in a similar case, so it is potentially worth swapping those to a different method as well.