### PR TITLE
fix: show grabbing cursor when dragging sliders

### DIFF
--- a/src/app/ui/components/playback-progress/playback-progress.component.html
+++ b/src/app/ui/components/playback-progress/playback-progress.component.html
@@ -1,5 +1,6 @@
 <div
     class="app-playback-progress-container"
+    [class.grabbing]="isProgressThumbDown || isProgressContainerDown"
     (mouseenter)="progressContainerMouseEnter()"
     (mouseleave)="progressContainerMouseLeave()"
     (mousedown)="progressContainerMouseDown($event)"

--- a/src/app/ui/components/playback-progress/playback-progress.component.scss
+++ b/src/app/ui/components/playback-progress/playback-progress.component.scss
@@ -3,6 +3,11 @@
     width: 100%;
     height: 12px;
     cursor: pointer;
+
+    &.grabbing,
+    &.grabbing .app-playback-progress-thumb {
+        cursor: grabbing;
+    }
 }
 
 .app-playback-progress-bar {

--- a/src/app/ui/components/slider/slider.component.html
+++ b/src/app/ui/components/slider/slider.component.html
@@ -1,5 +1,6 @@
 <div
     class="app-slider-container"
+    [class.grabbing]="isSliderThumbMovable"
     (mouseenter)="onSliderContainerMouseEnter()"
     (mouseleave)="onSliderContainerMouseLeave()"
     (mousedown)="onSliderContainerMouseDown($event)"

--- a/src/app/ui/components/slider/slider.component.scss
+++ b/src/app/ui/components/slider/slider.component.scss
@@ -3,6 +3,11 @@
     width: 100%;
     height: 12px;
     cursor: pointer;
+
+    &.grabbing,
+    &.grabbing .app-slider-thumb {
+        cursor: grabbing;
+    }
 }
 
 .app-slider-bar {

--- a/src/app/ui/components/slider/slider.component.ts
+++ b/src/app/ui/components/slider/slider.component.ts
@@ -60,7 +60,7 @@ export class SliderComponent implements AfterViewInit {
     public sliderTrack!: ElementRef;
 
     public showSliderThumb: boolean = false;
-    private isSliderThumbMovable: boolean = false;
+    public isSliderThumbMovable: boolean = false;
 
     public sliderBarPosition: number = 0;
     public sliderThumbPosition: number = 0;


### PR DESCRIPTION
- Make isSliderThumbMovable public to allow template binding
- Bind .grabbing class to slider container when thumb is being dragged
- Add grabbing cursor CSS rules to slider component
- Bind .grabbing class to progress bar container when dragging
- Add grabbing cursor CSS rules to playback progress component