### PR TITLE
fix: scope album shuffle to currently displayed albums

### DIFF
--- a/src/app/ui/components/collection/album-browser/album-browser.component.ts
+++ b/src/app/ui/components/collection/album-browser/album-browser.component.ts
@@ -223,7 +223,13 @@ export class AlbumBrowserComponent implements OnInit, AfterViewInit, OnChanges, 
     }
 
     public async shuffleAllAsync(): Promise<void> {
-        const tracks: TrackModels = this.trackService.getVisibleTracks();
+        if (!this.albums || this.albums.length === 0) {
+            return;
+        }
+
+        const albumKeys = this.albums.map(album => album.albumKey);
+        const tracks: TrackModels = this.trackService.getTracksForAlbums(albumKeys);
+        
         this.playbackService.forceShuffled();
         await this.playbackService.enqueueAndPlayTracksAsync(tracks.tracks);
     }


### PR DESCRIPTION
This PR fixes the behavior of the album shuffle button inside the `<app-album-browser>` component.

Previously, clicking the shuffle button would trigger `getVisibleTracks()`, which shuffled the entire global library. This update modifies the `shuffleAllAsync()` function to extract the keys of the currently rendered albums and fetch tracks exclusively from them using `getTracksForAlbums()`.

This ensures that shuffling from the Genres or Artists tabs respects the currently selected scope.

Fixes #1146