### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/main/background-work/common/application/sensitive-information.js
+++ b/main/background-work/common/application/sensitive-information.js
@@ -1,5 +1,5 @@
 class SensitiveInformation {
-    static lastfmApiKey = '1be93666a6e8d3d79b05b1c74682cb62';
+    static lastfmApiKey = process.env.LASTFM_API_KEY || '';
 }
 
 exports.SensitiveInformation = SensitiveInformation;

--- a/src/app/common/application/sensitive-information.ts
+++ b/src/app/common/application/sensitive-information.ts
@@ -1,5 +1,5 @@
 export class SensitiveInformation {
-    public static readonly lastfmApiKey: string = '1be93666a6e8d3d79b05b1c74682cb62';
-    public static readonly lastfmSharedSecret: string = 'c71f3fbae4ee6be95664d5406261094e';
-    public static readonly fanartApiKey: string = '80d1c44e9b315f0c1963857e4d671a85';
+    public static readonly lastfmApiKey: string = process.env.LASTFM_API_KEY || '';
+    public static readonly lastfmSharedSecret: string = process.env.LASTFM_SHARED_SECRET || '';
+    public static readonly fanartApiKey: string = process.env.FANART_API_KEY || '';
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src/app/common/application/sensitive-information.ts:L1`

Multiple API keys and secrets are hardcoded directly in the source code. The Last.fm API key and shared secret are present in both TypeScript and JavaScript files, and the Fanart.tv API key is also hardcoded. These credentials are committed to version control and exposed to anyone with access to the repository. Attackers can extract and abuse these keys for unauthorized API access, potentially exhausting rate limits, accessing paid features, or performing actions on behalf of the application.

## Solution

Remove all hardcoded credentials from source code. Use environment variables, a secure secrets management system, or Electron's safeStorage API to store and retrieve API keys at runtime. Consider rotating the exposed keys immediately as they are now compromised.

## Changes

- `src/app/common/application/sensitive-information.ts` (modified)
- `main/background-work/common/application/sensitive-information.js` (modified)