### PR TITLE
fix: Show in Folder fails for files on secondary drives under Snap confinement

### DIFF
--- a/src/app/common/io/desktop.spec.ts
+++ b/src/app/common/io/desktop.spec.ts
@@ -1,0 +1,124 @@
+import * as remote from '@electron/remote';
+import { Desktop } from './desktop';
+
+describe('Desktop', () => {
+    let shellMock: { showItemInFolder: jest.Mock; openPath: jest.Mock };
+
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    const originalSnap = process.env.SNAP;
+    const originalHome = process.env.HOME;
+
+    function createDesktop(): Desktop {
+        return Object.create(Desktop.prototype) as Desktop;
+    }
+
+    function setPlatform(platform: NodeJS.Platform): void {
+        Object.defineProperty(process, 'platform', {
+            value: platform,
+            configurable: true,
+        });
+    }
+
+    beforeEach(() => {
+        shellMock = {
+            showItemInFolder: jest.fn(),
+            openPath: jest.fn().mockResolvedValue(''),
+        };
+
+        (remote as unknown as { shell: typeof shellMock }).shell = shellMock;
+
+        process.env.HOME = '/home/me';
+        setPlatform('linux');
+        delete process.env.SNAP;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+
+        if (originalPlatformDescriptor != undefined) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+        }
+
+        if (originalSnap == undefined) {
+            delete process.env.SNAP;
+        } else {
+            process.env.SNAP = originalSnap;
+        }
+
+        if (originalHome == undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+
+        delete (remote as unknown as { shell?: typeof shellMock }).shell;
+    });
+
+    describe('showFileInDirectory', () => {
+        it('should show the item in its folder outside Snap', () => {
+            // Arrange
+            const desktop = createDesktop();
+
+            // Act
+            desktop.showFileInDirectory('/music/track.mp3');
+
+            // Assert
+            expect(shellMock.showItemInFolder).toHaveBeenCalledWith('/music/track.mp3');
+            expect(shellMock.openPath).not.toHaveBeenCalled();
+        });
+
+        it('should open the containing folder for Snap files outside the home directory', () => {
+            // Arrange
+            process.env.SNAP = '/snap/dopamine/current';
+            const desktop = createDesktop();
+
+            // Act
+            desktop.showFileInDirectory('/media/data/music/track.mp3');
+
+            // Assert
+            expect(shellMock.openPath).toHaveBeenCalledWith('/media/data/music');
+            expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+        });
+
+        it('should show the item in its folder for Snap files inside the home directory', () => {
+            // Arrange
+            process.env.SNAP = '/snap/dopamine/current';
+            const desktop = createDesktop();
+
+            // Act
+            desktop.showFileInDirectory('/home/me/Music/track.mp3');
+
+            // Assert
+            expect(shellMock.showItemInFolder).toHaveBeenCalledWith('/home/me/Music/track.mp3');
+            expect(shellMock.openPath).not.toHaveBeenCalled();
+        });
+
+        it('should open the mount point when the file is directly inside it', () => {
+            // Arrange
+            process.env.SNAP = '/snap/dopamine/current';
+            const desktop = createDesktop();
+
+            // Act
+            desktop.showFileInDirectory('/media/data/track.mp3');
+
+            // Assert
+            expect(shellMock.openPath).toHaveBeenCalledWith('/media/data');
+            expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+        });
+
+        it('should ignore rejected openPath promises', async () => {
+            // Arrange
+            process.env.SNAP = '/snap/dopamine/current';
+            shellMock.openPath.mockRejectedValue(new Error('Portal failed'));
+            const desktop = createDesktop();
+
+            // Act
+            expect(() => desktop.showFileInDirectory('/media/data/music/track.mp3')).not.toThrow();
+            await Promise.resolve();
+
+            // Assert
+            expect(shellMock.openPath).toHaveBeenCalledWith('/media/data/music');
+            expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/app/common/io/desktop.ts
+++ b/src/app/common/io/desktop.ts
@@ -2,6 +2,8 @@ import { Injectable, OnDestroy } from '@angular/core';
 import * as remote from '@electron/remote';
 import { ChildProcess, execSync, spawn } from 'child_process';
 import { OpenDialogReturnValue } from 'electron';
+import * as os from 'os';
+import * as path from 'path';
 import { Observable, Subject } from 'rxjs';
 import { DesktopBase } from './desktop.base';
 import SaveDialogReturnValue = Electron.SaveDialogReturnValue;
@@ -86,6 +88,11 @@ export class Desktop implements DesktopBase, OnDestroy {
     }
 
     public showFileInDirectory(filePath: string): void {
+        if (process.platform === 'linux' && process.env.SNAP != undefined && !this.isInHomeDirectory(filePath)) {
+            void remote.shell.openPath(path.dirname(filePath)).catch(() => undefined);
+            return;
+        }
+
         remote.shell.showItemInFolder(filePath);
     }
 
@@ -116,6 +123,18 @@ export class Desktop implements DesktopBase, OnDestroy {
     public setWindowAlwaysOnTop(alwaysOnTop: boolean): void {
         const win = remote.getCurrentWindow();
         win.setAlwaysOnTop(alwaysOnTop);
+    }
+
+    private isInHomeDirectory(filePath: string): boolean {
+        const homeDirectory = os.homedir();
+
+        if (homeDirectory === '') {
+            return false;
+        }
+
+        const relativePath = path.relative(path.resolve(homeDirectory), path.resolve(filePath));
+
+        return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
     }
 
     /**


### PR DESCRIPTION
## Summary
Dopamine's reveal path is `Desktop.showFileInDirectory()` in `src/app/common/io/desktop.ts`, a thin wrapper over `remote.shell.showItemInFolder(filePath)`. On Linux, Electron implements `showItemInFolder` with a direct D-Bus call to `org.freedesktop.FileManager1.ShowItems`, which Snap's AppArmor confinement blocks for paths outside the snap-visible home area, and the API returns void so the failure is silent. The fix stays inside `showFileInDirectory`: when running on Linux inside a Snap sandbox (`process.env.SNAP` is set) and the file is not under the user's home directory, fall back to `remote.shell.openPath(path.dirname(filePath))`, which routes through the snap's `xdg-open` portal shim and opens the containing folder for any mounted drive (losing only the file-highlight, not the whole action); all other platforms and the working home-directory case keep the existing `showItemInFolder` behavior.

## Why this matters
On Ubuntu with the Snap edition of Dopamine 3.0.4, the "Show in Folder" context-menu action does nothing when the selected track lives on a secondary storage drive (e.g. a mount outside /home), while the same action works for files under /home. The reporter includes a video reproduction and correctly suspects Snap's confinement model: a second user could not reproduce the problem with the unconfined RPM binary on a secondary btrfs drive, which isolates the failure to the Snap sandbox rather than Dopamine's core logic. Playback of the same files works, so the app can read them; only the file-manager reveal fails, silently.

See https://github.com/digimezzo/dopamine/issues/1111.

## Testing
- Non-snap environment (no SNAP env var): `showFileInDirectory('/music/track.mp3')` calls `shell.showItemInFolder` with the file path and never calls `shell.openPath`. - Snap environment, file outside home (e.g. `/media/data/music/track.mp3`): calls `shell.openPath` with the parent directory and does not call `shell.showItemInFolder`. - Snap environment, file inside the user's home directory: still calls `shell.showItemInFolder` (highlight behavior preserved where confinement allows it).

Fixes #1111
